### PR TITLE
Disable HR <-> MIN circle animation on old platforms

### DIFF
--- a/datetimepicker-library/src/com/sleepbot/datetimepicker/time/RadialPickerLayout.java
+++ b/datetimepicker-library/src/com/sleepbot/datetimepicker/time/RadialPickerLayout.java
@@ -522,6 +522,9 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
             Log.e(TAG, "TimePicker does not support view at index " + index);
             return;
         }
+        
+        //NineOldDroids does not work in this case due to denepency recursion. 
+        animate = animate && Build.VERSION.SDK_INT >= 14; 
 
         int lastIndex = getCurrentItemShowing();
         mCurrentItemShowing = index;


### PR DESCRIPTION
Animation on < API 14 devices have been buggy due to a recursive dependency that NineOldDroids does not support, we should just disable it here. 
