### PR TITLE
Added ability to set date range for datetimepicker and minimum minute interval for time picker

### DIFF
--- a/datetimepicker-library/res/values/colors.xml
+++ b/datetimepicker-library/res/values/colors.xml
@@ -8,6 +8,7 @@
     <color name="blue">#ff33b5e5</color>
     <color name="darker_blue">#ff0099cc</color>
     <color name="date_picker_text_normal">#ff999999</color>
+    <color name="date_picker_text_disabled">#ffcccccc</color>
     <color name="calendar_header">#ff999999</color>
     <color name="date_picker_view_animator">#fff2f2f2</color>
 

--- a/datetimepicker-library/res/values/colors.xml
+++ b/datetimepicker-library/res/values/colors.xml
@@ -13,6 +13,7 @@
 
     <color name="ampm_text_color">#8c8c8c</color>
     <color name="numbers_text_color">#8c8c8c</color>
+    <color name="numbers_disable_text_color">#e3e3e3</color>
 
     <color name="transparent_black">#7F000000</color>
 </resources>

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerController.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerController.java
@@ -6,7 +6,15 @@ abstract interface DatePickerController {
 	public abstract int getMaxYear();
 
 	public abstract int getMinYear();
+	
+	public abstract int getStartMonth();
 
+	public abstract int getEndMonth();
+	
+	public abstract int getStartDay();
+
+	public abstract int getEndDay();
+	
 	public abstract SimpleMonthAdapter.CalendarDay getSelectedDay();
 
 	public abstract void onDayOfMonthSelected(int year, int month, int day);

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
@@ -353,8 +353,6 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
 	}
 
 	public void setYearRange(int minYear, int maxYear) {
-		if (maxYear <= minYear)
-			throw new IllegalArgumentException("Year end must be larger than year start");
 		if (maxYear > MAX_YEAR)
 			throw new IllegalArgumentException("max year end must < " + MAX_YEAR);
 		if (minYear < MIN_YEAR)

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DayPickerView.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DayPickerView.java
@@ -63,8 +63,10 @@ public class DayPickerView extends ListView implements AbsListView.OnScrollListe
 	}
 
 	public boolean goTo(SimpleMonthAdapter.CalendarDay calendarDay, boolean scrollToTop, boolean selectDay, boolean displayMonth) {
-		if (selectDay)
+		if (selectDay) {
 			this.mSelectedDay.set(calendarDay);
+			this.mAdapter.setSelectedDay(this.mSelectedDay);
+		}
 
 		this.mTempDay.set(calendarDay);
 		int monthIndex = 12 * (calendarDay.year - this.mController.getMinYear()) - this.mController.getStartMonth() + calendarDay.month;

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DayPickerView.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DayPickerView.java
@@ -67,7 +67,7 @@ public class DayPickerView extends ListView implements AbsListView.OnScrollListe
 			this.mSelectedDay.set(calendarDay);
 
 		this.mTempDay.set(calendarDay);
-		int monthIndex = 12 * (calendarDay.year - this.mController.getMinYear()) + calendarDay.month;
+		int monthIndex = 12 * (calendarDay.year - this.mController.getMinYear()) - this.mController.getStartMonth() + calendarDay.month;
 		postSetSelection(monthIndex);
 
 		// TODO improve

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
@@ -61,11 +61,19 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
 		int selectedDay = -1;
 		if (isSelectedDayInMonth(year, month))
 			selectedDay = this.mSelectedDay.day;
+		int startDay = -1;
+		int endDay = 31;
+		if (this.mController.getStartMonth() == month && this.mController.getMinYear() == year)
+			startDay = this.mController.getStartDay();
+		if (this.mController.getEndMonth() == month && this.mController.getMaxYear() == year)
+			endDay = this.mController.getEndDay();
 		simpleMonthView.reuse();
 		monthParams.put("selected_day", Integer.valueOf(selectedDay));
 		monthParams.put("year", Integer.valueOf(year));
 		monthParams.put("month", Integer.valueOf(month));
 		monthParams.put("week_start", Integer.valueOf(this.mController.getFirstDayOfWeek()));
+		monthParams.put("start_day", Integer.valueOf(startDay));
+		monthParams.put("end_day", Integer.valueOf(endDay));
 		simpleMonthView.setMonthParams(monthParams);
 		simpleMonthView.invalidate();
 		return simpleMonthView;

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
@@ -29,7 +29,8 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
 	}
 
 	public int getCount() {
-		return 12 * (1 + (this.mController.getMaxYear() - this.mController.getMinYear()));
+		return 12 * (this.mController.getMaxYear() - this.mController.getMinYear()) 
+				+ this.mController.getEndMonth() - this.mController.getStartMonth() + 1;
 	}
 
 	public Object getItem(int position) {
@@ -54,8 +55,8 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
 		if (monthParams == null)
 			monthParams = new HashMap<String, Integer>();
 		monthParams.clear();
-		int month = position % 12;
-		int year = position / 12 + this.mController.getMinYear();
+		int month = (position + this.mController.getStartMonth()) % 12;	
+		int year = (position + this.mController.getStartMonth()) / 12 + this.mController.getMinYear();
 		Log.d("SimpleMonthAdapter", "Year: " + year + ", Month: " + month);
 		int selectedDay = -1;
 		if (isSelectedDayInMonth(year, month))

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthView.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthView.java
@@ -63,6 +63,9 @@ public class SimpleMonthView extends View {
 	protected int mWeekStart = 1;
 	protected int mWidth;
 	protected int mYear;
+	protected int mDayDisabledTextColor;
+	protected int mStartDay;
+	protected int mEndDay;
 	private DateFormatSymbols mDateFormatSymbols = new DateFormatSymbols();
 
 	public SimpleMonthView(Context context) {
@@ -73,6 +76,7 @@ public class SimpleMonthView extends View {
 		this.mDayOfWeekTypeface = resources.getString(R.string.day_of_week_label_typeface);
 		this.mMonthTitleTypeface = resources.getString(R.string.sans_serif);
 		this.mDayTextColor = resources.getColor(R.color.date_picker_text_normal);
+		this.mDayDisabledTextColor = resources.getColor(R.color.date_picker_text_disabled);
 		this.mTodayNumberColor = resources.getColor(R.color.blue);
 		this.mMonthTitleColor = resources.getColor(R.color.white);
 		this.mMonthTitleBGColor = resources.getColor(R.color.circle_background);
@@ -149,8 +153,11 @@ public class SimpleMonthView extends View {
 			int x = paddingDay * (1 + dayOffset * 2) + this.mPadding;
 			if (this.mSelectedDay == day)
 				canvas.drawCircle(x, y - MINI_DAY_NUMBER_TEXT_SIZE / 3, DAY_SELECTED_CIRCLE_SIZE, this.mSelectedCirclePaint);
+
 			if ((this.mHasToday) && (this.mToday == day))
 				this.mMonthNumPaint.setColor(this.mTodayNumberColor);
+			else if (day < this.mStartDay || day > this.mEndDay)
+				this.mMonthNumPaint.setColor(this.mDayDisabledTextColor);
 			else
 				this.mMonthNumPaint.setColor(this.mDayTextColor);
 			canvas.drawText(String.format("%d", day), x, y, this.mMonthNumPaint);
@@ -171,7 +178,9 @@ public class SimpleMonthView extends View {
 
 		int yDay = (int) (y - MONTH_HEADER_SIZE) / this.mRowHeight;
 		int day = 1 + ((int) ((x - padding) * this.mNumDays / (this.mWidth - padding - this.mPadding)) - findDayOffset()) + yDay * this.mNumDays;
-
+		// If day out of range
+		if (day < this.mStartDay || day > this.mEndDay)
+			return null;
 		return new SimpleMonthAdapter.CalendarDay(this.mYear, this.mMonth, day);
 	}
 
@@ -254,6 +263,8 @@ public class SimpleMonthView extends View {
 			this.mSelectedDay = ((Integer) monthParams.get("selected_day")).intValue();
 		this.mMonth = ((Integer) monthParams.get("month")).intValue();
 		this.mYear = ((Integer) monthParams.get("year")).intValue();
+		this.mStartDay = ((Integer) monthParams.get("start_day")).intValue();
+		this.mEndDay = ((Integer) monthParams.get("end_day")).intValue();
 		Time time = new Time(Time.getCurrentTimezone());
 		time.setToNow();
 		this.mHasToday = false;

--- a/datetimepicker-library/src/com/sleepbot/datetimepicker/time/RadialTextsView.java
+++ b/datetimepicker-library/src/com/sleepbot/datetimepicker/time/RadialTextsView.java
@@ -72,12 +72,17 @@ public class RadialTextsView extends View {
     ObjectAnimator mReappearAnimator;
     private InvalidateUpdateListener mInvalidateUpdateListener;
 
+    // Colors for text
+    private int numbersTextColor;
+    private int numbersDisabledTextColor;
+    private int[] textColors;
+    
     public RadialTextsView(Context context) {
         super(context);
         mIsInitialized = false;
     }
 
-    public void initialize(Resources res, String[] texts, String[] innerTexts,
+    public void initialize(Resources res, String[] texts, String[] innerTexts, boolean[] textEnabled,
                            boolean is24HourMode, boolean disappearsOut) {
         if (mIsInitialized) {
             Log.e(TAG, "This RadialTextsView may only be initialized once.");
@@ -85,8 +90,19 @@ public class RadialTextsView extends View {
         }
 
         // Set up the paint.
-        int numbersTextColor = res.getColor(R.color.numbers_text_color);
+        numbersTextColor = res.getColor(R.color.numbers_text_color);
+        numbersDisabledTextColor = res.getColor(R.color.numbers_disable_text_color);
         mPaint.setColor(numbersTextColor);
+        textColors = new int[12];
+        if (textEnabled != null) {
+            for (int i = 0 ; i < 12; i++) {
+                textColors[i] = textEnabled[i] ? numbersTextColor : numbersDisabledTextColor;
+            }
+        } else {
+            for (int i = 0 ; i < 12; i++) {
+                textColors[i] = numbersTextColor;
+            }
+        }
         String typefaceFamily = res.getString(R.string.radial_numbers_typeface);
         mTypefaceLight = Typeface.create(typefaceFamily, Typeface.NORMAL);
         String typefaceFamilyRegular = res.getString(R.string.sans_serif);
@@ -254,20 +270,15 @@ public class RadialTextsView extends View {
      */
     private void drawTexts(Canvas canvas, float textSize, Typeface typeface, String[] texts,
                            float[] textGridWidths, float[] textGridHeights) {
+        int[] widthIndices = {3,4,5,6,5,4,3,2,1,0,1,2};
+        int[] heightIndices = {0,1,2,3,4,5,6,5,4,3,2,1};
         mPaint.setTextSize(textSize);
         mPaint.setTypeface(typeface);
-        canvas.drawText(texts[0], textGridWidths[3], textGridHeights[0], mPaint);
-        canvas.drawText(texts[1], textGridWidths[4], textGridHeights[1], mPaint);
-        canvas.drawText(texts[2], textGridWidths[5], textGridHeights[2], mPaint);
-        canvas.drawText(texts[3], textGridWidths[6], textGridHeights[3], mPaint);
-        canvas.drawText(texts[4], textGridWidths[5], textGridHeights[4], mPaint);
-        canvas.drawText(texts[5], textGridWidths[4], textGridHeights[5], mPaint);
-        canvas.drawText(texts[6], textGridWidths[3], textGridHeights[6], mPaint);
-        canvas.drawText(texts[7], textGridWidths[2], textGridHeights[5], mPaint);
-        canvas.drawText(texts[8], textGridWidths[1], textGridHeights[4], mPaint);
-        canvas.drawText(texts[9], textGridWidths[0], textGridHeights[3], mPaint);
-        canvas.drawText(texts[10], textGridWidths[1], textGridHeights[2], mPaint);
-        canvas.drawText(texts[11], textGridWidths[2], textGridHeights[1], mPaint);
+        for (int i = 0 ; i < 12; i++) {
+            mPaint.setColor(textColors[i]);
+            canvas.drawText(texts[i], textGridWidths[widthIndices[i]], textGridHeights[heightIndices[i]], mPaint);
+        }
+        mPaint.setColor(numbersTextColor);
     }
 
     /**

--- a/datetimepicker-library/src/com/sleepbot/datetimepicker/time/TimePickerDialog.java
+++ b/datetimepicker-library/src/com/sleepbot/datetimepicker/time/TimePickerDialog.java
@@ -55,6 +55,8 @@ public class TimePickerDialog extends DialogFragment implements RadialPickerLayo
     private static final String KEY_IN_KB_MODE = "in_kb_mode";
     private static final String KEY_TYPED_TIMES = "typed_times";
     private static final String KEY_VIBRATE = "vibrate";
+    private static final String KEY_MINUTES_INTERVAL = "minutes_interval";
+
 
     public static final int HOUR_INDEX = 0;
     public static final int MINUTE_INDEX = 1;
@@ -108,6 +110,8 @@ public class TimePickerDialog extends DialogFragment implements RadialPickerLayo
     // Enable/Disable Vibrations
     private boolean mVibrate = true;
 
+    private int mMinutesInterval;
+    
     /**
      * The callback interface used to indicate the user is done filling in
      * the time (they clicked on the 'Set' button).
@@ -147,6 +151,7 @@ public class TimePickerDialog extends DialogFragment implements RadialPickerLayo
         mIs24HourMode = is24HourMode;
         mInKbMode = false;
         mVibrate = vibrate;
+        mMinutesInterval = 1;
     }
 
     public void setOnTimeSetListener(OnTimeSetListener callback) {
@@ -165,6 +170,14 @@ public class TimePickerDialog extends DialogFragment implements RadialPickerLayo
             mTimePicker.setVibrate(vibrate);
     }
 
+    /**
+     * Sets up the minimum minute interval that can be selected. Default value is 1.
+     * @param minutesInterval   The minimum increment for the minutes selector.
+     */
+    public void setMinutesInterval(int minutesInterval) {
+        mMinutesInterval = minutesInterval;
+    }
+    
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -176,6 +189,8 @@ public class TimePickerDialog extends DialogFragment implements RadialPickerLayo
             mIs24HourMode = savedInstanceState.getBoolean(KEY_IS_24_HOUR_VIEW);
             mInKbMode = savedInstanceState.getBoolean(KEY_IN_KB_MODE);
             mVibrate = savedInstanceState.getBoolean(KEY_VIBRATE);
+            mMinutesInterval = savedInstanceState.getInt(KEY_MINUTES_INTERVAL);
+
         }
     }
 
@@ -228,7 +243,7 @@ public class TimePickerDialog extends DialogFragment implements RadialPickerLayo
         mTimePicker = (RadialPickerLayout) view.findViewById(R.id.time_picker);
         mTimePicker.setOnValueSelectedListener(this);
         mTimePicker.setOnKeyListener(keyboardListener);
-        mTimePicker.initialize(getActivity(), mInitialHourOfDay, mInitialMinute, mIs24HourMode, mVibrate);
+        mTimePicker.initialize(getActivity(), mInitialHourOfDay, mInitialMinute, mIs24HourMode, mVibrate, mMinutesInterval);
         int currentItemShowing = HOUR_INDEX;
         if (savedInstanceState != null &&
                 savedInstanceState.containsKey(KEY_CURRENT_ITEM_SHOWING)) {
@@ -346,6 +361,7 @@ public class TimePickerDialog extends DialogFragment implements RadialPickerLayo
                 outState.putIntegerArrayList(KEY_TYPED_TIMES, mTypedTimes);
             }
             outState.putBoolean(KEY_VIBRATE, mVibrate);
+            outState.putInt(KEY_MINUTES_INTERVAL, mMinutesInterval);
         }
     }
 

--- a/datetimepicker-sample/src/com/fourmob/datetimepicker/sample/MainActivity.java
+++ b/datetimepicker-sample/src/com/fourmob/datetimepicker/sample/MainActivity.java
@@ -44,6 +44,8 @@ public class MainActivity extends FragmentActivity implements OnDateSetListener,
             @Override
             public void onClick(View v) {
                 timePickerDialog.setVibrate(isVibrate());
+                // Default is to allow every minute to be selected.
+                timePickerDialog.setMinutesInterval(1);
                 timePickerDialog.show(getSupportFragmentManager(), TIMEPICKER_TAG);
             }
         });

--- a/datetimepicker-sample/src/com/fourmob/datetimepicker/sample/MainActivity.java
+++ b/datetimepicker-sample/src/com/fourmob/datetimepicker/sample/MainActivity.java
@@ -36,6 +36,10 @@ public class MainActivity extends FragmentActivity implements OnDateSetListener,
             public void onClick(View v) {
                 datePickerDialog.setVibrate(isVibrate());
                 datePickerDialog.setYearRange(1985, 2028);
+
+                // Alternatively, you can set the date range of the Date Picker
+                // datePickerDialog.setDateRange(startYear, startMonth, startDay, endYear, endMonth, endDay);
+
                 datePickerDialog.show(getSupportFragmentManager(), DATEPICKER_TAG);
             }
         });


### PR DESCRIPTION
Set the date range by calling: datePickerDialog.setDateRange(startYear, startMonth, startDay, endYear, endMonth, endDay);
Days outside this period will be disabled.

The minute interval restricts you to select every 1/5/10/15 etc minutes (defaults to 1).
The minute interval can be changed for the time picker by calling setMinutesInterval(val);
