### PR TITLE
Remove log statement from SimpleMonthAdapter

### DIFF
--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
@@ -56,7 +56,6 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
 		monthParams.clear();
 		int month = position % 12;
 		int year = position / 12 + this.mController.getMinYear();
-		Log.d("SimpleMonthAdapter", "Year: " + year + ", Month: " + month);
 		int selectedDay = -1;
 		if (isSelectedDayInMonth(year, month))
 			selectedDay = this.mSelectedDay.day;


### PR DESCRIPTION
This log statement fill the entire log. 
I think it it is not needed in release version of library.
