### PR TITLE
Changes the range check to allow minYear and maxYear to be the same

### DIFF
--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
@@ -386,7 +386,7 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
 	}
 
 	public void setYearRange(int minYear, int maxYear) {
-		if (maxYear <= minYear)
+		if (maxYear < minYear)
 			throw new IllegalArgumentException("Year end must be larger than year start");
 		if (maxYear > MAX_YEAR)
 			throw new IllegalArgumentException("max year end must < " + MAX_YEAR);


### PR DESCRIPTION
I think it should be possible to use the same year for min and max year targets. If I want to, say, select dates of 2014 this would be the only way to do this. Thus I chnages this one line to allow to do so.
