### PR TITLE
Modify layout styles for Material Design

### DIFF
--- a/datetimepicker-library/res/color/date_picker_selector.xml
+++ b/datetimepicker-library/res/color/date_picker_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector
   xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_pressed="true" android:color="@color/darker_blue" />
-    <item android:state_selected="true" android:state_pressed="false" android:color="@color/blue" />
-    <item android:state_selected="false" android:state_pressed="false" android:color="@color/date_picker_text_normal" />
+    <item android:state_pressed="true" android:color="@color/grey" />
+    <item android:state_selected="true" android:state_pressed="false" android:color="@color/white" />
+    <item android:state_selected="false" android:state_pressed="false" android:color="@color/transparent_white" />
 </selector>

--- a/datetimepicker-library/res/layout-land/date_picker_dialog.xml
+++ b/datetimepicker-library/res/layout-land/date_picker_dialog.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout android:gravity="center" android:orientation="horizontal" android:layout_width="fill_parent" android:layout_height="@dimen/date_picker_view_animator_height"
+<LinearLayout android:gravity="center" android:orientation="vertical" android:layout_width="fill_parent" android:layout_height="@dimen/date_picker_view_animator_height"
   xmlns:android="http://schemas.android.com/apk/res/android">
-    <LinearLayout android:layout_gravity="center" android:orientation="vertical" android:background="@color/white" android:layout_width="wrap_content" android:layout_height="fill_parent">
-        <LinearLayout android:orientation="vertical" android:layout_width="wrap_content" android:layout_height="0.0dip" android:layout_weight="1.0">
+    <LinearLayout android:layout_gravity="center" android:orientation="horizontal" android:background="@color/white" android:layout_width="wrap_content" android:layout_height="fill_parent">
+        <LinearLayout android:orientation="vertical" android:layout_width="0.0dip" android:layout_height="match_parent" android:layout_weight="1.0">
             <include layout="@layout/date_picker_header_view" />
             <include layout="@layout/date_picker_selected_date" />
         </LinearLayout>
-        <include layout="@layout/date_picker_done_button" />
+        <include layout="@layout/date_picker_view_animator" />
     </LinearLayout>
-    <include layout="@layout/date_picker_view_animator" />
+    <include layout="@layout/date_picker_done_button" android:layout_width="match_parent" android:layout_height="wrap_content" />
 </LinearLayout>

--- a/datetimepicker-library/res/layout-land/date_picker_dialog.xml
+++ b/datetimepicker-library/res/layout-land/date_picker_dialog.xml
@@ -8,5 +8,5 @@
         </LinearLayout>
         <include layout="@layout/date_picker_view_animator" />
     </LinearLayout>
-    <include layout="@layout/date_picker_done_button" android:layout_width="match_parent" android:layout_height="wrap_content" />
+    <include layout="@layout/picker_done_button" android:layout_width="match_parent" android:layout_height="wrap_content" />
 </LinearLayout>

--- a/datetimepicker-library/res/layout-land/date_picker_dialog.xml
+++ b/datetimepicker-library/res/layout-land/date_picker_dialog.xml
@@ -6,7 +6,6 @@
             <include layout="@layout/date_picker_header_view" />
             <include layout="@layout/date_picker_selected_date" />
         </LinearLayout>
-        <View android:background="@color/line_background" android:layout_width="fill_parent" android:layout_height="1.0dip" />
         <include layout="@layout/date_picker_done_button" />
     </LinearLayout>
     <include layout="@layout/date_picker_view_animator" />

--- a/datetimepicker-library/res/layout-land/time_picker_dialog.xml
+++ b/datetimepicker-library/res/layout-land/time_picker_dialog.xml
@@ -16,56 +16,38 @@
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/time_picker_dialog"
-    android:layout_height="@dimen/dialog_height"
+    android:layout_height="wrap_content"
     android:layout_width="wrap_content"
-    android:orientation="horizontal"
+    android:orientation="vertical"
     android:focusable="true"
     android:layout_marginLeft="@dimen/minimum_margin_sides"
     android:layout_marginRight="@dimen/minimum_margin_sides"
     android:layout_marginTop="@dimen/minimum_margin_top_bottom"
     android:layout_marginBottom="@dimen/minimum_margin_top_bottom" >
     <LinearLayout
-        android:layout_width="@dimen/left_side_width"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/dialog_height"
+        android:orientation="horizontal">
         <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dip"
-            android:layout_weight="1"
-            android:background="@color/white" >
+            android:layout_width="@dimen/left_side_width"
+            android:layout_height="match_parent"
+            android:background="@color/blue" >
             <include
                 layout="@layout/time_header_label"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/header_height"
                 android:layout_gravity="center" />
         </FrameLayout>
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dip"
-            android:background="@color/line_background" />
-        <LinearLayout
-            style="?android:attr/buttonBarStyle"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:background="@color/white" >
-            <Button
-                android:id="@+id/done_button"
-                style="?android:attr/buttonBarButtonStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:minHeight="48dp"
-                android:text="@string/done_label"
-                android:textSize="@dimen/done_label_size"
-                android:textColor="@color/done_text_color" />
-        </LinearLayout>
+        <com.sleepbot.datetimepicker.time.RadialPickerLayout
+            android:id="@+id/time_picker"
+            android:layout_width="@dimen/picker_dimen"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:background="@color/circle_background" />
     </LinearLayout>
-    <com.sleepbot.datetimepicker.time.RadialPickerLayout
-        android:id="@+id/time_picker"
-        android:layout_width="@dimen/picker_dimen"
-        android:layout_height="match_parent"
-        android:layout_gravity="center"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
-        android:background="@color/circle_background" />
+    <include layout="@layout/picker_done_button"
+             android:layout_height="wrap_content"
+             android:layout_width="match_parent" />
 </LinearLayout>

--- a/datetimepicker-library/res/layout-sw600dp-land/date_picker_dialog.xml
+++ b/datetimepicker-library/res/layout-sw600dp-land/date_picker_dialog.xml
@@ -8,5 +8,5 @@
         </LinearLayout>
         <include layout="@layout/date_picker_view_animator" />
     </LinearLayout>
-    <include layout="@layout/date_picker_done_button" />
+    <include layout="@layout/picker_done_button" />
 </LinearLayout>

--- a/datetimepicker-library/res/layout-sw600dp-land/date_picker_dialog.xml
+++ b/datetimepicker-library/res/layout-sw600dp-land/date_picker_dialog.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout android:gravity="center" android:orientation="horizontal" android:layout_width="fill_parent" android:layout_height="@dimen/date_picker_view_animator_height"
+<LinearLayout android:gravity="center" android:orientation="vertical" android:layout_width="fill_parent" android:layout_height="@dimen/date_picker_view_animator_height"
   xmlns:android="http://schemas.android.com/apk/res/android">
-    <LinearLayout android:layout_gravity="center" android:orientation="vertical" android:background="@color/white" android:layout_width="wrap_content" android:layout_height="fill_parent">
-        <LinearLayout android:orientation="vertical" android:layout_width="wrap_content" android:layout_height="0.0dip" android:layout_weight="1.0">
+    <LinearLayout android:layout_gravity="center" android:orientation="horizontal" android:background="@color/white" android:layout_width="wrap_content" android:layout_height="fill_parent">
+        <LinearLayout android:orientation="vertical" android:layout_width="0.0dip" android:layout_height="match_parent" android:layout_weight="1.0">
             <include layout="@layout/date_picker_header_view" />
             <include layout="@layout/date_picker_selected_date" />
         </LinearLayout>
-        <include layout="@layout/date_picker_done_button" />
+        <include layout="@layout/date_picker_view_animator" />
     </LinearLayout>
-    <include layout="@layout/date_picker_view_animator" />
+    <include layout="@layout/date_picker_done_button" />
 </LinearLayout>

--- a/datetimepicker-library/res/layout-sw600dp-land/date_picker_dialog.xml
+++ b/datetimepicker-library/res/layout-sw600dp-land/date_picker_dialog.xml
@@ -6,7 +6,6 @@
             <include layout="@layout/date_picker_header_view" />
             <include layout="@layout/date_picker_selected_date" />
         </LinearLayout>
-        <View android:background="@color/line_background" android:layout_width="fill_parent" android:layout_height="1.0dip" />
         <include layout="@layout/date_picker_done_button" />
     </LinearLayout>
     <include layout="@layout/date_picker_view_animator" />

--- a/datetimepicker-library/res/layout-sw600dp/date_picker_dialog.xml
+++ b/datetimepicker-library/res/layout-sw600dp/date_picker_dialog.xml
@@ -6,5 +6,5 @@
         <include layout="@layout/date_picker_selected_date" />
     </LinearLayout>
     <include layout="@layout/date_picker_view_animator" />
-    <include layout="@layout/date_picker_done_button" />
+    <include layout="@layout/picker_done_button" />
 </LinearLayout>

--- a/datetimepicker-library/res/layout-sw600dp/date_picker_dialog.xml
+++ b/datetimepicker-library/res/layout-sw600dp/date_picker_dialog.xml
@@ -6,6 +6,5 @@
         <include layout="@layout/date_picker_selected_date" />
     </LinearLayout>
     <include layout="@layout/date_picker_view_animator" />
-    <View android:background="@color/line_background" android:layout_width="fill_parent" android:layout_height="1.0dip" />
     <include layout="@layout/date_picker_done_button" />
 </LinearLayout>

--- a/datetimepicker-library/res/layout-w270dp-h560dp/date_picker_dialog.xml
+++ b/datetimepicker-library/res/layout-w270dp-h560dp/date_picker_dialog.xml
@@ -6,5 +6,5 @@
         <include layout="@layout/date_picker_selected_date" />
     </LinearLayout>
     <include layout="@layout/date_picker_view_animator" />
-    <include layout="@layout/date_picker_done_button" />
+    <include layout="@layout/picker_done_button" />
 </LinearLayout>

--- a/datetimepicker-library/res/layout-w270dp-h560dp/date_picker_dialog.xml
+++ b/datetimepicker-library/res/layout-w270dp-h560dp/date_picker_dialog.xml
@@ -6,6 +6,5 @@
         <include layout="@layout/date_picker_selected_date" />
     </LinearLayout>
     <include layout="@layout/date_picker_view_animator" />
-    <View android:background="@color/line_background" android:layout_width="fill_parent" android:layout_height="1.0dip" />
     <include layout="@layout/date_picker_done_button" />
 </LinearLayout>

--- a/datetimepicker-library/res/layout/date_picker_dialog.xml
+++ b/datetimepicker-library/res/layout/date_picker_dialog.xml
@@ -5,5 +5,5 @@
         <include layout="@layout/date_picker_selected_date" />
     </LinearLayout>
     <include layout="@layout/date_picker_view_animator" />
-    <include layout="@layout/date_picker_done_button" />
+    <include layout="@layout/picker_done_button" />
 </LinearLayout>

--- a/datetimepicker-library/res/layout/date_picker_dialog.xml
+++ b/datetimepicker-library/res/layout/date_picker_dialog.xml
@@ -5,6 +5,5 @@
         <include layout="@layout/date_picker_selected_date" />
     </LinearLayout>
     <include layout="@layout/date_picker_view_animator" />
-    <View android:background="@color/line_background" android:layout_width="@dimen/date_picker_component_width" android:layout_height="1.0dip" />
     <include layout="@layout/date_picker_done_button" />
 </LinearLayout>

--- a/datetimepicker-library/res/layout/date_picker_done_button.xml
+++ b/datetimepicker-library/res/layout/date_picker_done_button.xml
@@ -1,18 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="@dimen/date_picker_component_width"
     android:layout_height="wrap_content"
+    android:padding="@dimen/view_margin_medium"
     style="?android:attr/buttonBarStyle">
 
     <Button
         android:textSize="@dimen/done_label_size"
         android:textColor="@color/done_text_color"
-        android:id="@id/done"
-        android:layout_width="fill_parent"
+        android:id="@id/cancel"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:minHeight="48dip"
+        android:layout_margin="@dimen/view_margin_medium"
+        android:text="@string/cancel_label"
+        android:layout_toStartOf="@id/done"
+        android:layout_toLeftOf="@id/done"
+        style="@style/button_bar_button" />
+
+    <Button
+        android:textSize="@dimen/done_label_size"
+        android:textColor="@color/done_text_color"
+        android:id="@id/done"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_margin="@dimen/view_margin_medium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="@string/done_label"
-        style="?android:attr/buttonBarButtonStyle" />
-</LinearLayout>
+        style="@style/button_bar_button" />
+</RelativeLayout>

--- a/datetimepicker-library/res/layout/date_picker_selected_date.xml
+++ b/datetimepicker-library/res/layout/date_picker_selected_date.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout android:gravity="center" android:orientation="vertical" android:id="@id/day_picker_selected_date_layout" android:background="@color/white" android:layout_width="@dimen/date_picker_component_width" android:layout_height="0.0dip" android:layout_weight="1.0"
+<LinearLayout android:gravity="center" android:orientation="vertical" android:id="@id/day_picker_selected_date_layout" android:background="@color/blue" android:layout_width="@dimen/date_picker_component_width" android:layout_height="0.0dip" android:layout_weight="1.0"
   xmlns:android="http://schemas.android.com/apk/res/android">
     <LinearLayout android:textColor="@color/date_picker_selector" android:layout_gravity="center" android:orientation="vertical" android:id="@id/date_picker_month_and_day" android:clickable="true" android:layout_width="fill_parent" android:layout_height="wrap_content">
         <TextView android:textSize="@dimen/selected_date_month_size" android:textColor="@color/date_picker_selector" android:gravity="bottom|center" android:id="@id/date_picker_month" android:duplicateParentState="true" android:layout_width="fill_parent" android:layout_height="wrap_content" android:includeFontPadding="false" />

--- a/datetimepicker-library/res/layout/picker_done_button.xml
+++ b/datetimepicker-library/res/layout/picker_done_button.xml
@@ -4,6 +4,7 @@
     android:orientation="vertical"
     android:layout_width="@dimen/date_picker_component_width"
     android:layout_height="wrap_content"
+    android:background="@color/circle_background"
     android:padding="@dimen/view_margin_medium"
     style="?android:attr/buttonBarStyle">
 

--- a/datetimepicker-library/res/layout/picker_done_button.xml
+++ b/datetimepicker-library/res/layout/picker_done_button.xml
@@ -10,19 +10,19 @@
     <Button
         android:textSize="@dimen/done_label_size"
         android:textColor="@color/done_text_color"
-        android:id="@id/cancel"
+        android:id="@id/cancel_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/view_margin_medium"
         android:text="@string/cancel_label"
-        android:layout_toStartOf="@id/done"
-        android:layout_toLeftOf="@id/done"
+        android:layout_toStartOf="@id/done_button"
+        android:layout_toLeftOf="@id/done_button"
         style="@style/button_bar_button" />
 
     <Button
         android:textSize="@dimen/done_label_size"
         android:textColor="@color/done_text_color"
-        android:id="@id/done"
+        android:id="@id/done_button"
         android:layout_alignParentEnd="true"
         android:layout_alignParentRight="true"
         android:layout_margin="@dimen/view_margin_medium"

--- a/datetimepicker-library/res/layout/time_header_label.xml
+++ b/datetimepicker-library/res/layout/time_header_label.xml
@@ -18,7 +18,7 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:layout_gravity="center"
-      android:background="@color/white" >
+      android:background="@color/blue" >
         <View
             android:id="@+id/center_view"
             android:layout_width="1dp"
@@ -51,7 +51,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/time_placeholder"
-                android:textColor="@color/blue"
+                android:textColor="@color/white"
                 android:gravity="center_horizontal"
                 android:layout_gravity="center"
                 style="@style/time_label" />

--- a/datetimepicker-library/res/layout/time_picker_dialog.xml
+++ b/datetimepicker-library/res/layout/time_picker_dialog.xml
@@ -39,23 +39,7 @@
         android:layout_gravity="center"
         android:focusable="true"
         android:focusableInTouchMode="true" />
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dip"
-        android:background="@color/line_background" />
-    <LinearLayout
-        style="?android:attr/buttonBarStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal" >
-        <Button
-            android:id="@+id/done_button"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="48dp"
-            android:text="@string/done_label"
-            android:textSize="@dimen/done_label_size"
-            android:textColor="@color/done_text_color"
-            style="?android:attr/buttonBarButtonStyle" />
-    </LinearLayout>
+    <include layout="@layout/picker_done_button"
+             android:layout_height="wrap_content"
+             android:layout_width="match_parent" />
 </LinearLayout>

--- a/datetimepicker-library/res/values-v14/styles.xml
+++ b/datetimepicker-library/res/values-v14/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="button_bar_button" parent="@android:style/Widget.Holo.Button.Borderless">
+        <item name="android:gravity">center</item>
+        <item name="android:minHeight">36dip</item>
+        <item name="android:minWidth">64dip</item>
+        <item name="android:paddingBottom">8dip</item>
+        <item name="android:paddingTop">8dip</item>
+        <item name="android:textAllCaps">true</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+</resources>

--- a/datetimepicker-library/res/values-v16/strings.xml
+++ b/datetimepicker-library/res/values-v16/strings.xml
@@ -16,5 +16,5 @@
 
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <!-- DO NOT TRANSLATE -->
-    <string name="day_of_week_label_typeface">sans-serif-light</string>
+    <string name="day_of_week_label_typeface">sans-serif-medium</string>
 </resources>

--- a/datetimepicker-library/res/values-v17/styles.xml
+++ b/datetimepicker-library/res/values-v17/styles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+</resources>

--- a/datetimepicker-library/res/values/colors.xml
+++ b/datetimepicker-library/res/values/colors.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="white">#ffffffff</color>
+    <color name="grey">#ddd</color>
     <color name="circle_background">#fff2f2f2</color>
     <color name="line_background">#ffcccccc</color>
     <color name="done_text_color_normal">@color/blue</color>
@@ -8,11 +9,12 @@
     <color name="blue">#ff33b5e5</color>
     <color name="darker_blue">#ff0099cc</color>
     <color name="date_picker_text_normal">#ff999999</color>
-    <color name="calendar_header">#ff999999</color>
+    <color name="calendar_header">@color/darker_blue</color>
     <color name="date_picker_view_animator">#fff2f2f2</color>
 
     <color name="ampm_text_color">#8c8c8c</color>
     <color name="numbers_text_color">#8c8c8c</color>
 
+    <color name="transparent_white">#aaffffff</color>
     <color name="transparent_black">#7F000000</color>
 </resources>

--- a/datetimepicker-library/res/values/colors.xml
+++ b/datetimepicker-library/res/values/colors.xml
@@ -3,7 +3,7 @@
     <color name="white">#ffffffff</color>
     <color name="circle_background">#fff2f2f2</color>
     <color name="line_background">#ffcccccc</color>
-    <color name="done_text_color_normal">#ff333333</color>
+    <color name="done_text_color_normal">@color/blue</color>
     <color name="done_text_color_disabled">#ffcccccc</color>
     <color name="blue">#ff33b5e5</color>
     <color name="darker_blue">#ff0099cc</color>

--- a/datetimepicker-library/res/values/dimens.xml
+++ b/datetimepicker-library/res/values/dimens.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="done_label_size">14sp</dimen>
+    <dimen name="done_button_panel_height">48dip</dimen>
     <dimen name="date_picker_component_width">270dip</dimen>
     <dimen name="date_picker_header_height">30dip</dimen>
     <dimen name="selected_calendar_layout_height">155dip</dimen>
@@ -27,6 +28,8 @@
     <dimen name="picker_dimen">270dip</dimen>
     <dimen name="minimum_margin_sides">48dip</dimen>
     <dimen name="minimum_margin_top_bottom">24dip</dimen>
+
+    <dimen name="view_margin_medium">8dip</dimen>
 
     <item name="circle_radius_multiplier" format="float" type="string">0.82</item>
     <item name="circle_radius_multiplier_24HourMode" format="float" type="string">0.85</item>

--- a/datetimepicker-library/res/values/dimens.xml
+++ b/datetimepicker-library/res/values/dimens.xml
@@ -7,7 +7,7 @@
     <dimen name="selected_calendar_layout_height">155dip</dimen>
     <dimen name="date_picker_view_animator_height">270dip</dimen>
     <dimen name="month_list_item_header_height">50dip</dimen>
-    <dimen name="month_day_label_text_size">10sp</dimen>
+    <dimen name="month_day_label_text_size">12sp</dimen>
     <dimen name="day_number_select_circle_radius">16dip</dimen>
     <dimen name="month_select_circle_radius">45dip</dimen>
     <dimen name="selected_date_year_size">30dip</dimen>
@@ -15,7 +15,7 @@
     <dimen name="selected_date_month_size">30dip</dimen>
     <dimen name="date_picker_header_text_size">14dip</dimen>
     <dimen name="month_label_size">16sp</dimen>
-    <dimen name="day_number_size">16sp</dimen>
+    <dimen name="day_number_size">12sp</dimen>
     <dimen name="year_label_height">64dip</dimen>
     <dimen name="year_label_text_size">22dip</dimen>
 

--- a/datetimepicker-library/res/values/ids.xml
+++ b/datetimepicker-library/res/values/ids.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <item type="id" name="done">false</item>
+    <item type="id" name="cancel">false</item>
     <item type="id" name="date_picker_header">false</item>
     <item type="id" name="day_picker_selected_date_layout">false</item>
     <item type="id" name="date_picker_month_and_day">false</item>

--- a/datetimepicker-library/res/values/ids.xml
+++ b/datetimepicker-library/res/values/ids.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item type="id" name="done">false</item>
-    <item type="id" name="cancel">false</item>
+    <item type="id" name="done_button">false</item>
+    <item type="id" name="cancel_button">false</item>
     <item type="id" name="date_picker_header">false</item>
     <item type="id" name="day_picker_selected_date_layout">false</item>
     <item type="id" name="date_picker_month_and_day">false</item>

--- a/datetimepicker-library/res/values/strings.xml
+++ b/datetimepicker-library/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="http://schemas.android.com/apk/res/android">
-    <string name="done_label">Done</string>
+    <string name="done_label">OK</string>
+    <string name="cancel_label">Cancel</string>
     <string name="day_picker_description">Month grid of days</string>
     <string name="year_picker_description">Year list</string>
     <string name="select_day">Select month and day</string>

--- a/datetimepicker-library/res/values/styles.xml
+++ b/datetimepicker-library/res/values/styles.xml
@@ -17,12 +17,12 @@
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
     <style name="time_label">
         <item name="android:textSize">@dimen/time_label_size</item>
-        <item name="android:textColor">@color/numbers_text_color</item>
+        <item name="android:textColor">@color/transparent_white</item>
     </style>
 
     <style name="ampm_label">
         <item name="android:textSize">@dimen/ampm_label_size</item>
-        <item name="android:textColor">@color/ampm_text_color</item>
+        <item name="android:textColor">@color/transparent_white</item>
         <item name="android:textStyle">bold</item>
     </style>
 

--- a/datetimepicker-library/res/values/styles.xml
+++ b/datetimepicker-library/res/values/styles.xml
@@ -27,4 +27,16 @@
     </style>
 
     <style name="day_of_week_label_condensed" />
+
+    <style name="button_bar_button">
+        <item name="android:background">?android:attr/selectableItemBackground</item>
+        <item name="android:gravity">center</item>
+        <item name="android:minHeight">36dip</item>
+        <item name="android:minWidth">64dip</item>
+        <item name="android:paddingBottom">8dip</item>
+        <item name="android:paddingLeft">8dip</item>
+        <item name="android:paddingTop">8dip</item>
+        <item name="android:paddingRight">8dip</item>
+        <item name="android:textStyle">bold</item>
+    </style>
 </resources>

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
@@ -76,7 +76,6 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
 
 	private TextView mDayOfWeekView;
 	private DayPickerView mDayPickerView;
-	private Button mDoneButton;
 	private LinearLayout mMonthAndDayView;
 	private TextView mSelectedDayTextView;
 	private TextView mSelectedMonthTextView;
@@ -297,12 +296,19 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
 		outAlphaAnimation.setDuration(300L);
 		mAnimator.setOutAnimation(outAlphaAnimation);
 
-		mDoneButton = ((Button) view.findViewById(R.id.done));
-		mDoneButton.setOnClickListener(new View.OnClickListener() {
-			public void onClick(View view) {
+		Button doneButton = ((Button) view.findViewById(R.id.done));
+        Button cancelButton = ((Button) view.findViewById(R.id.cancel));
+		doneButton.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View view) {
                 onDoneButtonClick();
-			}
-		});
+            }
+        });
+        cancelButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                dismiss();
+            }
+        });
 
 		updateDisplay(false);
 		setCurrentView(currentView, true);
@@ -322,7 +328,7 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
         tryVibrate();
         if (mCallBack != null) {
             mCallBack.onDateSet(this, mCalendar.get(Calendar.YEAR), mCalendar.get(Calendar.MONTH), mCalendar.get(Calendar.DAY_OF_MONTH));
-}
+        }
         dismiss();
     }
 

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
@@ -1,6 +1,7 @@
 package com.fourmob.datetimepicker.date;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.SystemClock;
@@ -239,7 +240,7 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
 		super.onCreate(bundle);
 		Activity activity = getActivity();
 		activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-		mVibrator = ((Vibrator) activity.getSystemService("vibrator"));
+		mVibrator = ((Vibrator) activity.getSystemService(Context.VIBRATOR_SERVICE));
 		if (bundle != null) {
 			mCalendar.set(Calendar.YEAR, bundle.getInt(KEY_SELECTED_YEAR));
 			mCalendar.set(Calendar.MONTH, bundle.getInt(KEY_SELECTED_MONTH));

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
@@ -296,8 +296,8 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
 		outAlphaAnimation.setDuration(300L);
 		mAnimator.setOutAnimation(outAlphaAnimation);
 
-		Button doneButton = ((Button) view.findViewById(R.id.done));
-        Button cancelButton = ((Button) view.findViewById(R.id.cancel));
+		Button doneButton = ((Button) view.findViewById(R.id.done_button));
+        Button cancelButton = ((Button) view.findViewById(R.id.cancel_button));
 		doneButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View view) {
                 onDoneButtonClick();

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
@@ -173,7 +173,7 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
             this.mDayOfWeekView.setText(mDateFormatSymbols.getWeekdays()[this.mCalendar.get(Calendar.DAY_OF_WEEK)].toUpperCase(Locale.getDefault()));
         }
 
-        this.mSelectedMonthTextView.setText(mDateFormatSymbols.getMonths()[this.mCalendar.get(Calendar.MONTH)].toUpperCase(Locale.getDefault()));
+        this.mSelectedMonthTextView.setText(mDateFormatSymbols.getShortMonths()[this.mCalendar.get(Calendar.MONTH)].toUpperCase(Locale.getDefault()));
 
         mSelectedDayTextView.setText(DAY_FORMAT.format(mCalendar.getTime()));
         mYearView.setText(YEAR_FORMAT.format(mCalendar.getTime()));

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthView.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthView.java
@@ -130,7 +130,8 @@ public class SimpleMonthView extends View {
             int calendarDay = (i + mWeekStart) % mNumDays;
             int x = (2 * i + 1) * dayWidthHalf + mPadding;
             mDayLabelCalendar.set(Calendar.DAY_OF_WEEK, calendarDay);
-            canvas.drawText(mDateFormatSymbols.getShortWeekdays()[mDayLabelCalendar.get(Calendar.DAY_OF_WEEK)].toUpperCase(Locale.getDefault()), x, y, mMonthDayLabelPaint);
+            canvas.drawText(mDateFormatSymbols.getShortWeekdays()[mDayLabelCalendar
+                    .get(Calendar.DAY_OF_WEEK)].toUpperCase(Locale.getDefault()).substring(0, 1), x, y, mMonthDayLabelPaint);
         }
 	}
 

--- a/datetimepicker-library/src/com/sleepbot/datetimepicker/time/TimePickerDialog.java
+++ b/datetimepicker-library/src/com/sleepbot/datetimepicker/time/TimePickerDialog.java
@@ -264,6 +264,13 @@ public class TimePickerDialog extends DialogFragment implements RadialPickerLayo
             }
         });
         mDoneButton.setOnKeyListener(keyboardListener);
+        
+        view.findViewById(R.id.cancel_button).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                dismiss();
+            }
+        });
 
         // Enable or disable the AM/PM view.
         mAmPmHitspace = view.findViewById(R.id.ampm_hitspace);

--- a/datetimepicker-library/src/com/sleepbot/datetimepicker/time/TimePickerDialog.java
+++ b/datetimepicker-library/src/com/sleepbot/datetimepicker/time/TimePickerDialog.java
@@ -78,8 +78,8 @@ public class TimePickerDialog extends DialogFragment implements RadialPickerLayo
     private View mAmPmHitspace;
     private RadialPickerLayout mTimePicker;
 
-    private int mBlue;
-    private int mBlack;
+    private int mWhite;
+    private int mUnfocusedWhite;
     private String mAmText;
     private String mPmText;
 
@@ -197,8 +197,8 @@ public class TimePickerDialog extends DialogFragment implements RadialPickerLayo
         mSelectHours = res.getString(R.string.select_hours);
         mMinutePickerDescription = res.getString(R.string.minute_picker_description);
         mSelectMinutes = res.getString(R.string.select_minutes);
-        mBlue = res.getColor(R.color.blue);
-        mBlack = res.getColor(R.color.numbers_text_color);
+        mWhite = res.getColor(R.color.white);
+        mUnfocusedWhite = res.getColor(R.color.transparent_white);
 
         mHourView = (TextView) view.findViewById(R.id.hours);
         mHourView.setOnKeyListener(keyboardListener);
@@ -440,8 +440,8 @@ public class TimePickerDialog extends DialogFragment implements RadialPickerLayo
             labelToAnimate = mMinuteView;
         }
 
-        int hourColor = (index == HOUR_INDEX) ? mBlue : mBlack;
-        int minuteColor = (index == MINUTE_INDEX) ? mBlue : mBlack;
+        int hourColor = (index == HOUR_INDEX) ? mWhite : mUnfocusedWhite;
+        int minuteColor = (index == MINUTE_INDEX) ? mWhite : mUnfocusedWhite;
         mHourView.setTextColor(hourColor);
         mMinuteView.setTextColor(minuteColor);
 
@@ -661,10 +661,10 @@ public class TimePickerDialog extends DialogFragment implements RadialPickerLayo
                     String.format(minuteFormat, values[1]).replace(' ', mPlaceholderText);
             mHourView.setText(hourStr);
             mHourSpaceView.setText(hourStr);
-            mHourView.setTextColor(mBlack);
+            mHourView.setTextColor(mUnfocusedWhite);
             mMinuteView.setText(minuteStr);
             mMinuteSpaceView.setText(minuteStr);
-            mMinuteView.setTextColor(mBlack);
+            mMinuteView.setTextColor(mUnfocusedWhite);
             if (!mIs24HourMode) {
                 updateAmPmDisplay(values[2]);
             }


### PR DESCRIPTION
Made layout changes to match the current [Material guidelines for Pickers](http://www.google.com/design/spec/components/pickers.html).

Android Lollipop has native `DatePicker`s and `TimePicker`s that look like the following:

<img src="https://cloud.githubusercontent.com/assets/375956/5152887/4274ed1e-71d6-11e4-88ca-0e9588a3bae3.png" align="left" height="350" width="200" >

<img src="https://cloud.githubusercontent.com/assets/375956/5152900/e34fba0c-71d6-11e4-9eb5-7ca9205aec9a.png" height="350" width="200" >

These new pickers are not ported to pre-Android 5.0, even with AppCompat, so I followed the guidelines as close as possible to create a similar look for this library:

<img src="https://cloud.githubusercontent.com/assets/375956/5152908/825f94a0-71d7-11e4-8213-f95a1a9af78f.png" align="left" height="350" width="200" >

<img src="https://cloud.githubusercontent.com/assets/375956/5152912/ab7e3814-71d7-11e4-87fa-346ce5e3783a.png" height="350" width="200" >

<img src="https://cloud.githubusercontent.com/assets/375956/5152921/6ee5945a-71d8-11e4-87f7-a49bf8e559e3.png" height="200" width="350" >

<img src="https://cloud.githubusercontent.com/assets/375956/5152922/903774ac-71d8-11e4-8c03-3103b2378455.png" height="200" width="350" >

while still retaining the original color theme used in this repo (if anyone needs to use custom colors, please see https://github.com/flavienlaurent/datetimepicker/issues/65#issuecomment-58580121)

Changes made are mostly to layout or style xml files. Commits are self-contained and easy to review. 

Tested on Nexus 7, 5 & 4.
