### PR TITLE
add support for minDate: all dates before will be disabled

### DIFF
--- a/datetimepicker-library/res/values/dimens.xml
+++ b/datetimepicker-library/res/values/dimens.xml
@@ -17,6 +17,7 @@
     <dimen name="day_number_size">16sp</dimen>
     <dimen name="year_label_height">64dip</dimen>
     <dimen name="year_label_text_size">22dip</dimen>
+    <dimen name="month_view_bottom_pad">6dp</dimen>
 
     <dimen name="time_label_size">60sp</dimen>
     <dimen name="extra_time_label_margin">-30dp</dimen>

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
@@ -24,6 +24,7 @@ import com.nineoldandroids.animation.ObjectAnimator;
 import java.text.DateFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Locale;
@@ -36,11 +37,11 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
     private static final String KEY_VIBRATE = "vibrate";
 
     // https://code.google.com/p/android/issues/detail?id=13050
-	private static final int MAX_YEAR = 2037;
-	private static final int MIN_YEAR = 1902;
+    private static final int MAX_YEAR = 2037;
+    private static final int MIN_YEAR = 1902;
 
     private static final int UNINITIALIZED = -1;
-	private static final int MONTH_AND_DAY_VIEW = 0;
+    private static final int MONTH_AND_DAY_VIEW = 0;
     private static final int YEAR_VIEW = 1;
 
     public static final int ANIMATION_DELAY = 500;
@@ -52,10 +53,10 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
     public static final String KEY_LIST_POSITION_OFFSET = "list_position_offset";
 
     private static SimpleDateFormat DAY_FORMAT = new SimpleDateFormat("dd", Locale.getDefault());
-	private static SimpleDateFormat YEAR_FORMAT = new SimpleDateFormat("yyyy", Locale.getDefault());
+    private static SimpleDateFormat YEAR_FORMAT = new SimpleDateFormat("yyyy", Locale.getDefault());
     private DateFormatSymbols mDateFormatSymbols = new DateFormatSymbols();
 
-	private final Calendar mCalendar = Calendar.getInstance();
+    private final Calendar mCalendar = Calendar.getInstance();
     private HashSet<OnDateChangedListener> mListeners = new HashSet<OnDateChangedListener>();
     private OnDateSetListener mCallBack;
 
@@ -73,18 +74,20 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
     private String mSelectDay;
     private String mSelectYear;
 
-	private TextView mDayOfWeekView;
-	private DayPickerView mDayPickerView;
-	private Button mDoneButton;
-	private LinearLayout mMonthAndDayView;
-	private TextView mSelectedDayTextView;
-	private TextView mSelectedMonthTextView;
-	private Vibrator mVibrator;
-	private YearPickerView mYearPickerView;
-	private TextView mYearView;
+    private TextView mDayOfWeekView;
+    private DayPickerView mDayPickerView;
+    private Button mDoneButton;
+    private LinearLayout mMonthAndDayView;
+    private TextView mSelectedDayTextView;
+    private TextView mSelectedMonthTextView;
+    private Vibrator mVibrator;
+    private YearPickerView mYearPickerView;
+    private TextView mYearView;
 
     private boolean mVibrate = true;
     private boolean mCloseOnSingleTapDay;
+    private SimpleMonthAdapter.CalendarDay minDate;
+    private boolean viewInitialized = false;
 
     private void adjustDayInMonthIfNeeded(int month, int year) {
         int day = mCalendar.get(Calendar.DAY_OF_MONTH);
@@ -92,74 +95,82 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
         if (day > daysInMonth) {
             mCalendar.set(Calendar.DAY_OF_MONTH, daysInMonth);
         }
-	}
+    }
 
     public DatePickerDialog() {
         // Empty constructor required for dialog fragment. DO NOT REMOVE
     }
 
-	public static DatePickerDialog newInstance(OnDateSetListener onDateSetListener, int year, int month, int day) {
-		return newInstance(onDateSetListener, year, month, day, true);
-	}
+    public static DatePickerDialog newInstance(OnDateSetListener onDateSetListener, int year, int month, int day) {
+        return newInstance(onDateSetListener, year, month, day, true);
+    }
 
-	public static DatePickerDialog newInstance(OnDateSetListener onDateSetListener, int year, int month, int day, boolean vibrate) {
-		DatePickerDialog datePickerDialog = new DatePickerDialog();
-		datePickerDialog.initialize(onDateSetListener, year, month, day, vibrate);
-		return datePickerDialog;
-	}
+    public static DatePickerDialog newInstance(OnDateSetListener onDateSetListener, int year, int month, int day, boolean vibrate) {
+        DatePickerDialog datePickerDialog = new DatePickerDialog();
+        datePickerDialog.initialize(onDateSetListener, year, month, day, vibrate);
+        return datePickerDialog;
+    }
+
+    public void setMinDate(SimpleMonthAdapter.CalendarDay minDate) {
+        if (mDayPickerView != null) {
+            mDayPickerView.setMinDate(minDate);
+        } else {
+            this.minDate = minDate;
+        }
+    }
 
 
-	public void setVibrate(boolean vibrate) {
-		mVibrate = vibrate;
-	}
+    public void setVibrate(boolean vibrate) {
+        mVibrate = vibrate;
+    }
 
-	private void setCurrentView(int currentView) {
-		setCurrentView(currentView, false);
-	}
+    private void setCurrentView(int currentView) {
+        setCurrentView(currentView, false);
+    }
 
-	private void setCurrentView(int currentView, boolean forceRefresh) {
-		long timeInMillis = mCalendar.getTimeInMillis();
-		switch (currentView) {
-		case MONTH_AND_DAY_VIEW:
-			ObjectAnimator monthDayAnim = Utils.getPulseAnimator(mMonthAndDayView, 0.9F, 1.05F);
-			if (mDelayAnimation) {
-				monthDayAnim.setStartDelay(ANIMATION_DELAY);
-				mDelayAnimation = false;
-			}
-			mDayPickerView.onDateChanged();
-			if (mCurrentView != currentView || forceRefresh) {
-				mMonthAndDayView.setSelected(true);
-				mYearView.setSelected(false);
-				mAnimator.setDisplayedChild(MONTH_AND_DAY_VIEW);
-				mCurrentView = currentView;
-			}
-			monthDayAnim.start();
-			String monthDayDesc = DateUtils.formatDateTime(getActivity(), timeInMillis, DateUtils.FORMAT_SHOW_DATE);
-			mAnimator.setContentDescription(mDayPickerDescription + ": " + monthDayDesc);
-            Utils.tryAccessibilityAnnounce(mAnimator, mSelectDay);
-            break;
-		case YEAR_VIEW:
-			ObjectAnimator yearAnim = Utils.getPulseAnimator(mYearView, 0.85F, 1.1F);
-			if (mDelayAnimation) {
-				yearAnim.setStartDelay(ANIMATION_DELAY);
-				mDelayAnimation = false;
-			}
-			mYearPickerView.onDateChanged();
-			if (mCurrentView != currentView  || forceRefresh) {
-				mMonthAndDayView.setSelected(false);
-				mYearView.setSelected(true);
-				mAnimator.setDisplayedChild(YEAR_VIEW);
-				mCurrentView = currentView;
-			}
-			yearAnim.start();
-			String dayDesc = YEAR_FORMAT.format(timeInMillis);
-			mAnimator.setContentDescription(mYearPickerDescription + ": " + dayDesc);
-            Utils.tryAccessibilityAnnounce(mAnimator, mSelectYear);
-            break;
-		}
-	}
+    private void setCurrentView(int currentView, boolean forceRefresh) {
+        long timeInMillis = mCalendar.getTimeInMillis();
+        switch (currentView) {
+            case MONTH_AND_DAY_VIEW:
+                ObjectAnimator monthDayAnim = Utils.getPulseAnimator(mMonthAndDayView, 0.9F, 1.05F);
+                if (mDelayAnimation) {
+                    monthDayAnim.setStartDelay(ANIMATION_DELAY);
+                    mDelayAnimation = false;
+                }
+                mDayPickerView.onDateChanged();
+                if (mCurrentView != currentView || forceRefresh) {
+                    mMonthAndDayView.setSelected(true);
+                    mYearView.setSelected(false);
+                    mAnimator.setDisplayedChild(MONTH_AND_DAY_VIEW);
+                    mCurrentView = currentView;
+                }
+                monthDayAnim.start();
+                String monthDayDesc = DateUtils.formatDateTime(getActivity(), timeInMillis, DateUtils.FORMAT_SHOW_DATE);
+                mAnimator.setContentDescription(mDayPickerDescription + ": " + monthDayDesc);
+                Utils.tryAccessibilityAnnounce(mAnimator, mSelectDay);
+                break;
+            case YEAR_VIEW:
+                ObjectAnimator yearAnim = Utils.getPulseAnimator(mYearView, 0.85F, 1.1F);
+                if (mDelayAnimation) {
+                    yearAnim.setStartDelay(ANIMATION_DELAY);
+                    mDelayAnimation = false;
+                }
+                mYearPickerView.onDateChanged();
+                if (mCurrentView != currentView || forceRefresh) {
+                    mMonthAndDayView.setSelected(false);
+                    mYearView.setSelected(true);
+                    mAnimator.setDisplayedChild(YEAR_VIEW);
+                    mCurrentView = currentView;
+                }
+                yearAnim.start();
+                String dayDesc = YEAR_FORMAT.format(timeInMillis);
+                mAnimator.setContentDescription(mYearPickerDescription + ": " + dayDesc);
+                Utils.tryAccessibilityAnnounce(mAnimator, mSelectYear);
+                break;
+        }
+    }
 
-	private void updateDisplay(boolean announce) {
+    private void updateDisplay(boolean announce) {
         /*if (mDayOfWeekView != null) {
             mDayOfWeekView.setText(mCalendar.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG,
                     Locale.getDefault()).toUpperCase(Locale.getDefault()));
@@ -168,15 +179,13 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
         mSelectedMonthTextView.setText(mCalendar.getDisplayName(Calendar.MONTH, Calendar.SHORT,
                 Locale.getDefault()).toUpperCase(Locale.getDefault()));*/
 
-        if (this.mDayOfWeekView != null){
+        if (this.mDayOfWeekView != null) {
             this.mCalendar.setFirstDayOfWeek(mWeekStart);
             this.mDayOfWeekView.setText(mDateFormatSymbols.getWeekdays()[this.mCalendar.get(Calendar.DAY_OF_WEEK)].toUpperCase(Locale.getDefault()));
         }
-
-        this.mSelectedMonthTextView.setText(mDateFormatSymbols.getMonths()[this.mCalendar.get(Calendar.MONTH)].toUpperCase(Locale.getDefault()));
-
-        mSelectedDayTextView.setText(DAY_FORMAT.format(mCalendar.getTime()));
-        mYearView.setText(YEAR_FORMAT.format(mCalendar.getTime()));
+            this.mSelectedMonthTextView.setText(mDateFormatSymbols.getMonths()[this.mCalendar.get(Calendar.MONTH)].toUpperCase(Locale.getDefault()));
+            mSelectedDayTextView.setText(DAY_FORMAT.format(mCalendar.getTime()));
+            mYearView.setText(YEAR_FORMAT.format(mCalendar.getTime()));
 
         // Accessibility.
         long millis = mCalendar.getTimeInMillis();
@@ -190,187 +199,191 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
             String fullDateText = DateUtils.formatDateTime(getActivity(), millis, flags);
             Utils.tryAccessibilityAnnounce(mAnimator, fullDateText);
         }
-	}
+    }
 
-	private void updatePickers() {
+    private void updatePickers() {
         Iterator<OnDateChangedListener> iterator = mListeners.iterator();
         while (iterator.hasNext()) {
             iterator.next().onDateChanged();
         }
-	}
+    }
 
-	public int getFirstDayOfWeek() {
-		return mWeekStart;
-	}
+    public int getFirstDayOfWeek() {
+        return mWeekStart;
+    }
 
-	public int getMaxYear() {
-		return mMaxYear;
-	}
+    public int getMaxYear() {
+        return mMaxYear;
+    }
 
-	public int getMinYear() {
-		return mMinYear;
-	}
+    public int getMinYear() {
+        return mMinYear;
+    }
 
-	public SimpleMonthAdapter.CalendarDay getSelectedDay() {
-		return new SimpleMonthAdapter.CalendarDay(mCalendar);
-	}
+    public SimpleMonthAdapter.CalendarDay getSelectedDay() {
+        return new SimpleMonthAdapter.CalendarDay(mCalendar);
+    }
 
-	public void initialize(OnDateSetListener onDateSetListener, int year, int month, int day, boolean vibrate) {
-		if (year > MAX_YEAR)
-			throw new IllegalArgumentException("year end must < " + MAX_YEAR);
-		if (year < MIN_YEAR)
-			throw new IllegalArgumentException("year end must > " + MIN_YEAR);
-		mCallBack = onDateSetListener;
-		mCalendar.set(Calendar.YEAR, year);
-		mCalendar.set(Calendar.MONTH, month);
-		mCalendar.set(Calendar.DAY_OF_MONTH, day);
-		mVibrate = vibrate;
-	}
+    public void initialize(OnDateSetListener onDateSetListener, int year, int month, int day, boolean vibrate) {
+        if (year > MAX_YEAR)
+            throw new IllegalArgumentException("year end must < " + MAX_YEAR);
+        if (year < MIN_YEAR)
+            throw new IllegalArgumentException("year end must > " + MIN_YEAR);
+        mCallBack = onDateSetListener;
+        mCalendar.set(Calendar.YEAR, year);
+        mCalendar.set(Calendar.MONTH, month);
+        mCalendar.set(Calendar.DAY_OF_MONTH, day);
+        mVibrate = vibrate;
+    }
 
-	public void onClick(View view) {
-		tryVibrate();
-		if (view.getId() == R.id.date_picker_year)
-			setCurrentView(YEAR_VIEW);
-		else if (view.getId() == R.id.date_picker_month_and_day)
-			setCurrentView(MONTH_AND_DAY_VIEW);
-	}
+    public void onClick(View view) {
+        tryVibrate();
+        if (view.getId() == R.id.date_picker_year)
+            setCurrentView(YEAR_VIEW);
+        else if (view.getId() == R.id.date_picker_month_and_day)
+            setCurrentView(MONTH_AND_DAY_VIEW);
+    }
 
-	public void onCreate(Bundle bundle) {
-		super.onCreate(bundle);
-		Activity activity = getActivity();
-		activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-		mVibrator = ((Vibrator) activity.getSystemService("vibrator"));
-		if (bundle != null) {
-			mCalendar.set(Calendar.YEAR, bundle.getInt(KEY_SELECTED_YEAR));
-			mCalendar.set(Calendar.MONTH, bundle.getInt(KEY_SELECTED_MONTH));
-			mCalendar.set(Calendar.DAY_OF_MONTH, bundle.getInt(KEY_SELECTED_DAY));
-			mVibrate = bundle.getBoolean(KEY_VIBRATE);
-		}
-	}
+    public void onCreate(Bundle bundle) {
+        super.onCreate(bundle);
+        Activity activity = getActivity();
+        activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+        mVibrator = ((Vibrator) activity.getSystemService("vibrator"));
+        if (bundle != null) {
+            mCalendar.set(Calendar.YEAR, bundle.getInt(KEY_SELECTED_YEAR));
+            mCalendar.set(Calendar.MONTH, bundle.getInt(KEY_SELECTED_MONTH));
+            mCalendar.set(Calendar.DAY_OF_MONTH, bundle.getInt(KEY_SELECTED_DAY));
+            mVibrate = bundle.getBoolean(KEY_VIBRATE);
+        }
+    }
 
-	public View onCreateView(LayoutInflater layoutInflater, ViewGroup parent, Bundle bundle) {
-		getDialog().getWindow().requestFeature(Window.FEATURE_NO_TITLE);
+    public View onCreateView(LayoutInflater layoutInflater, ViewGroup parent, Bundle bundle) {
+        getDialog().getWindow().requestFeature(Window.FEATURE_NO_TITLE);
+        this.viewInitialized = true;
+        View view = layoutInflater.inflate(R.layout.date_picker_dialog, null);
 
-		View view = layoutInflater.inflate(R.layout.date_picker_dialog, null);
+        mDayOfWeekView = ((TextView) view.findViewById(R.id.date_picker_header));
+        mMonthAndDayView = ((LinearLayout) view.findViewById(R.id.date_picker_month_and_day));
+        mMonthAndDayView.setOnClickListener(this);
+        mSelectedMonthTextView = ((TextView) view.findViewById(R.id.date_picker_month));
+        mSelectedDayTextView = ((TextView) view.findViewById(R.id.date_picker_day));
+        mYearView = ((TextView) view.findViewById(R.id.date_picker_year));
+        mYearView.setOnClickListener(this);
 
-		mDayOfWeekView = ((TextView) view.findViewById(R.id.date_picker_header));
-		mMonthAndDayView = ((LinearLayout) view.findViewById(R.id.date_picker_month_and_day));
-		mMonthAndDayView.setOnClickListener(this);
-		mSelectedMonthTextView = ((TextView) view.findViewById(R.id.date_picker_month));
-		mSelectedDayTextView = ((TextView) view.findViewById(R.id.date_picker_day));
-		mYearView = ((TextView) view.findViewById(R.id.date_picker_year));
-		mYearView.setOnClickListener(this);
+        int listPosition = -1;
+        int currentView = MONTH_AND_DAY_VIEW;
+        int listPositionOffset = 0;
+        if (bundle != null) {
+            mWeekStart = bundle.getInt(KEY_WEEK_START);
+            mMinYear = bundle.getInt(KEY_YEAR_START);
+            mMaxYear = bundle.getInt(KEY_YEAR_END);
+            currentView = bundle.getInt(KEY_CURRENT_VIEW);
+            listPosition = bundle.getInt(KEY_LIST_POSITION);
+            listPositionOffset = bundle.getInt(KEY_LIST_POSITION_OFFSET);
+        }
 
-		int listPosition = -1;
-		int currentView = MONTH_AND_DAY_VIEW;
-		int listPositionOffset = 0;
-		if (bundle != null) {
-			mWeekStart = bundle.getInt(KEY_WEEK_START);
-			mMinYear = bundle.getInt(KEY_YEAR_START);
-			mMaxYear = bundle.getInt(KEY_YEAR_END);
-			currentView = bundle.getInt(KEY_CURRENT_VIEW);
-			listPosition = bundle.getInt(KEY_LIST_POSITION);
-			listPositionOffset = bundle.getInt(KEY_LIST_POSITION_OFFSET);
-		}
+        Activity activity = getActivity();
+        mDayPickerView = new DayPickerView(activity, this);
+        if (this.minDate != null) mDayPickerView.setMinDate(this.minDate);
+        mYearPickerView = new YearPickerView(activity, this);
 
-		Activity activity = getActivity();
-		mDayPickerView = new DayPickerView(activity, this);
-		mYearPickerView = new YearPickerView(activity, this);
+        Resources resources = getResources();
+        mDayPickerDescription = resources.getString(R.string.day_picker_description);
+        mSelectDay = resources.getString(R.string.select_day);
+        mYearPickerDescription = resources.getString(R.string.year_picker_description);
+        mSelectYear = resources.getString(R.string.select_year);
 
-		Resources resources = getResources();
-		mDayPickerDescription = resources.getString(R.string.day_picker_description);
-		mSelectDay = resources.getString(R.string.select_day);
-		mYearPickerDescription = resources.getString(R.string.year_picker_description);
-		mSelectYear = resources.getString(R.string.select_year);
+        mAnimator = ((AccessibleDateAnimator) view.findViewById(R.id.animator));
+        mAnimator.addView(mDayPickerView);
+        mAnimator.addView(mYearPickerView);
+        mAnimator.setDateMillis(mCalendar.getTimeInMillis());
 
-		mAnimator = ((AccessibleDateAnimator) view.findViewById(R.id.animator));
-		mAnimator.addView(mDayPickerView);
-		mAnimator.addView(mYearPickerView);
-		mAnimator.setDateMillis(mCalendar.getTimeInMillis());
+        AlphaAnimation inAlphaAnimation = new AlphaAnimation(0.0F, 1.0F);
+        inAlphaAnimation.setDuration(300L);
+        mAnimator.setInAnimation(inAlphaAnimation);
 
-		AlphaAnimation inAlphaAnimation = new AlphaAnimation(0.0F, 1.0F);
-		inAlphaAnimation.setDuration(300L);
-		mAnimator.setInAnimation(inAlphaAnimation);
+        AlphaAnimation outAlphaAnimation = new AlphaAnimation(1.0F, 0.0F);
+        outAlphaAnimation.setDuration(300L);
+        mAnimator.setOutAnimation(outAlphaAnimation);
 
-		AlphaAnimation outAlphaAnimation = new AlphaAnimation(1.0F, 0.0F);
-		outAlphaAnimation.setDuration(300L);
-		mAnimator.setOutAnimation(outAlphaAnimation);
-
-		mDoneButton = ((Button) view.findViewById(R.id.done));
-		mDoneButton.setOnClickListener(new View.OnClickListener() {
-			public void onClick(View view) {
+        mDoneButton = ((Button) view.findViewById(R.id.done));
+        mDoneButton.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View view) {
                 onDoneButtonClick();
-			}
-		});
+            }
+        });
 
-		updateDisplay(false);
-		setCurrentView(currentView, true);
+        updateDisplay(false);
+        setCurrentView(currentView, true);
 
-		if (listPosition != -1) {
-			if (currentView == MONTH_AND_DAY_VIEW) {
-				mDayPickerView.postSetSelection(listPosition);
-			}
-			if (currentView == YEAR_VIEW) {
-				mYearPickerView.postSetSelectionFromTop(listPosition, listPositionOffset);
-			}
-		}
-		return view;
-	}
+        if (listPosition != -1) {
+            if (currentView == MONTH_AND_DAY_VIEW) {
+                mDayPickerView.postSetSelection(listPosition);
+            }
+            if (currentView == YEAR_VIEW) {
+                mYearPickerView.postSetSelectionFromTop(listPosition, listPositionOffset);
+            }
+        }
+        return view;
+    }
 
     private void onDoneButtonClick() {
         tryVibrate();
         if (mCallBack != null) {
             mCallBack.onDateSet(this, mCalendar.get(Calendar.YEAR), mCalendar.get(Calendar.MONTH), mCalendar.get(Calendar.DAY_OF_MONTH));
-}
+        }
         dismiss();
     }
 
     public void onDayOfMonthSelected(int year, int month, int day) {
-		mCalendar.set(Calendar.YEAR, year);
-		mCalendar.set(Calendar.MONTH, month);
-		mCalendar.set(Calendar.DAY_OF_MONTH, day);
-		updatePickers();
-		updateDisplay(true);
+        mCalendar.set(Calendar.YEAR, year);
+        mCalendar.set(Calendar.MONTH, month);
+        mCalendar.set(Calendar.DAY_OF_MONTH, day);
+        if(viewInitialized){
+            updatePickers();
+            updateDisplay(true);
 
-        if(mCloseOnSingleTapDay) {
-            onDoneButtonClick();
+            if (mCloseOnSingleTapDay) {
+                onDoneButtonClick();
+            }
         }
-	}
+    }
 
-	public void onSaveInstanceState(Bundle bundle) {
-		super.onSaveInstanceState(bundle);
-		bundle.putInt(KEY_SELECTED_YEAR, mCalendar.get(Calendar.YEAR));
-		bundle.putInt(KEY_SELECTED_MONTH, mCalendar.get(Calendar.MONTH));
-		bundle.putInt(KEY_SELECTED_DAY, mCalendar.get(Calendar.DAY_OF_MONTH));
-		bundle.putInt(KEY_WEEK_START, mWeekStart);
-		bundle.putInt(KEY_YEAR_START, mMinYear);
-		bundle.putInt(KEY_YEAR_END, mMaxYear);
-		bundle.putInt(KEY_CURRENT_VIEW, mCurrentView);
+    public void onSaveInstanceState(Bundle bundle) {
+        super.onSaveInstanceState(bundle);
+        bundle.putInt(KEY_SELECTED_YEAR, mCalendar.get(Calendar.YEAR));
+        bundle.putInt(KEY_SELECTED_MONTH, mCalendar.get(Calendar.MONTH));
+        bundle.putInt(KEY_SELECTED_DAY, mCalendar.get(Calendar.DAY_OF_MONTH));
+        bundle.putInt(KEY_WEEK_START, mWeekStart);
+        bundle.putInt(KEY_YEAR_START, mMinYear);
+        bundle.putInt(KEY_YEAR_END, mMaxYear);
+        bundle.putInt(KEY_CURRENT_VIEW, mCurrentView);
 
-		int listPosition = -1;
-		if (mCurrentView == 0) {
-			listPosition = mDayPickerView.getMostVisiblePosition();
-        } if (mCurrentView == 1) {
-			listPosition = mYearPickerView.getFirstVisiblePosition();
-			bundle.putInt(KEY_LIST_POSITION_OFFSET, mYearPickerView.getFirstPositionOffset());
-		}
+        int listPosition = -1;
+        if (mCurrentView == 0) {
+            listPosition = mDayPickerView.getMostVisiblePosition();
+        }
+        if (mCurrentView == 1) {
+            listPosition = mYearPickerView.getFirstVisiblePosition();
+            bundle.putInt(KEY_LIST_POSITION_OFFSET, mYearPickerView.getFirstPositionOffset());
+        }
         bundle.putInt(KEY_LIST_POSITION, listPosition);
-		bundle.putBoolean(KEY_VIBRATE, mVibrate);
-	}
+        bundle.putBoolean(KEY_VIBRATE, mVibrate);
+    }
 
-	public void onYearSelected(int year) {
-		adjustDayInMonthIfNeeded(mCalendar.get(Calendar.MONTH), year);
-		mCalendar.set(Calendar.YEAR, year);
-		updatePickers();
-		setCurrentView(MONTH_AND_DAY_VIEW);
-		updateDisplay(true);
-	}
+    public void onYearSelected(int year) {
+        adjustDayInMonthIfNeeded(mCalendar.get(Calendar.MONTH), year);
+        mCalendar.set(Calendar.YEAR, year);
+        updatePickers();
+        setCurrentView(MONTH_AND_DAY_VIEW);
+        updateDisplay(true);
+    }
 
-	public void registerOnDateChangedListener(OnDateChangedListener onDateChangedListener) {
-		mListeners.add(onDateChangedListener);
-	}
+    public void registerOnDateChangedListener(OnDateChangedListener onDateChangedListener) {
+        mListeners.add(onDateChangedListener);
+    }
 
-	public void setFirstDayOfWeek(int startOfWeek) {
+    public void setFirstDayOfWeek(int startOfWeek) {
         if (startOfWeek < Calendar.SUNDAY || startOfWeek > Calendar.SATURDAY) {
             throw new IllegalArgumentException("Value must be between Calendar.SUNDAY and " +
                     "Calendar.SATURDAY");
@@ -379,44 +392,50 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
         if (mDayPickerView != null) {
             mDayPickerView.onChange();
         }
-	}
+    }
 
-	public void setOnDateSetListener(OnDateSetListener onDateSetListener) {
-		mCallBack = onDateSetListener;
-	}
+    public void setOnDateSetListener(OnDateSetListener onDateSetListener) {
+        mCallBack = onDateSetListener;
+    }
 
-	public void setYearRange(int minYear, int maxYear) {
-		if (maxYear < minYear)
-			throw new IllegalArgumentException("Year end must be larger than year start");
-		if (maxYear > MAX_YEAR)
-			throw new IllegalArgumentException("max year end must < " + MAX_YEAR);
-		if (minYear < MIN_YEAR)
-			throw new IllegalArgumentException("min year end must > " + MIN_YEAR);
-		mMinYear = minYear;
-		mMaxYear = maxYear;
-		if (mDayPickerView != null)
-			mDayPickerView.onChange();
-	}
+    public void setYearRange(int minYear, int maxYear) {
+        if (maxYear < minYear)
+            throw new IllegalArgumentException("Year end must be larger than year start");
+        if (maxYear > MAX_YEAR)
+            throw new IllegalArgumentException("max year end must < " + MAX_YEAR);
+        if (minYear < MIN_YEAR)
+            throw new IllegalArgumentException("min year end must > " + MIN_YEAR);
+        mMinYear = minYear;
+        mMaxYear = maxYear;
+        if (mDayPickerView != null)
+            mDayPickerView.onChange();
+    }
 
-	public void tryVibrate() {
-		if (mVibrator != null && mVibrate) {
-			long timeInMillis = SystemClock.uptimeMillis();
-			if (timeInMillis - mLastVibrate >= 125L) {
-				mVibrator.vibrate(5L);
-				mLastVibrate = timeInMillis;
-			}
-		}
-	}
+    public void tryVibrate() {
+        if (mVibrator != null && mVibrate) {
+            long timeInMillis = SystemClock.uptimeMillis();
+            if (timeInMillis - mLastVibrate >= 125L) {
+                mVibrator.vibrate(5L);
+                mLastVibrate = timeInMillis;
+            }
+        }
+    }
 
     public void setCloseOnSingleTapDay(boolean closeOnSingleTapDay) {
         mCloseOnSingleTapDay = closeOnSingleTapDay;
     }
 
-    static abstract interface OnDateChangedListener {
-		public abstract void onDateChanged();
-	}
+    public void setSelectedDay(GregorianCalendar date) {
+        //mCalendar.set(date.get(GregorianCalendar.YEAR), date.get(GregorianCalendar.MONTH), date.get(GregorianCalendar.DAY_OF_MONTH));
+        onDayOfMonthSelected(date.get(GregorianCalendar.YEAR), date.get(GregorianCalendar.MONTH), date.get(GregorianCalendar.DAY_OF_MONTH));
+    }
 
-	public static abstract interface OnDateSetListener {
-		public abstract void onDateSet(DatePickerDialog datePickerDialog, int year, int month, int day);
-	}
+
+    static abstract interface OnDateChangedListener {
+        public abstract void onDateChanged();
+    }
+
+    public static abstract interface OnDateSetListener {
+        public abstract void onDateSet(DatePickerDialog datePickerDialog, int year, int month, int day);
+    }
 }

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
@@ -114,9 +114,8 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
     public void setMinDate(SimpleMonthAdapter.CalendarDay minDate) {
         if (mDayPickerView != null) {
             mDayPickerView.setMinDate(minDate);
-        } else {
-            this.minDate = minDate;
         }
+            this.minDate = minDate;
     }
 
 

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DayPickerView.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DayPickerView.java
@@ -126,7 +126,7 @@ public class DayPickerView extends ListView implements AbsListView.OnScrollListe
 	public void init(Context paramContext) {
 		mContext = paramContext;
 		setUpListView();
-		setUpAdapter();
+		setUpAdapter(null);
 		setAdapter(mAdapter);
 	}
 
@@ -138,7 +138,7 @@ public class DayPickerView extends ListView implements AbsListView.OnScrollListe
 	}
 
 	public void onChange() {
-		setUpAdapter();
+		setUpAdapter(null);
 		setAdapter(mAdapter);
 	}
 
@@ -177,11 +177,16 @@ public class DayPickerView extends ListView implements AbsListView.OnScrollListe
 		invalidateViews();
 	}
 
-	protected void setUpAdapter() {
+    public void setMinDate(SimpleMonthAdapter.CalendarDay day){
+        mAdapter.setMinDate(day);
+    }
+
+	protected void setUpAdapter(SimpleMonthAdapter.CalendarDay mMaxDate) {
 		if (mAdapter == null) {
 			mAdapter = new SimpleMonthAdapter(getContext(), mController);
         }
 		mAdapter.setSelectedDay(this.mSelectedDay);
+        mAdapter.setMinDate(mMaxDate);
 		mAdapter.notifyDataSetChanged();
 	}
 

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
@@ -1,60 +1,66 @@
 package com.fourmob.datetimepicker.date;
 
 import android.content.Context;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.AbsListView;
 import android.widget.BaseAdapter;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 
 public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.OnDayClickListener {
 
+    private static final String TAG = "SimpleMonthAdapter";
     protected static int WEEK_7_OVERHANG_HEIGHT = 7;
     protected static final int MONTHS_IN_YEAR = 12;
 
-	private final Context mContext;
-	private final DatePickerController mController;
+    private final Context mContext;
+    private final DatePickerController mController;
 
-	private CalendarDay mSelectedDay;
+    private CalendarDay mSelectedDay;
+    private CalendarDay mMinDate;
 
-	public SimpleMonthAdapter(Context context, DatePickerController datePickerController) {
-		mContext = context;
-		mController = datePickerController;
-		init();
-		setSelectedDay(mController.getSelectedDay());
-	}
+    public SimpleMonthAdapter(Context context, DatePickerController datePickerController) {
+        mContext = context;
+        mController = datePickerController;
+        init();
+        setSelectedDay(mController.getSelectedDay());
+    }
 
-	private boolean isSelectedDayInMonth(int year, int month) {
-		return (mSelectedDay.year == year) && (mSelectedDay.month == month);
-	}
+    private boolean isSelectedDayInMonth(int year, int month) {
+        return (mSelectedDay.year == year) && (mSelectedDay.month == month);
+    }
 
-	public int getCount() {
+    public int getCount() {
         return ((mController.getMaxYear() - mController.getMinYear()) + 1) * MONTHS_IN_YEAR;
-	}
+    }
 
-	public Object getItem(int position) {
-		return null;
-	}
+    public Object getItem(int position) {
+        return null;
+    }
 
-	public long getItemId(int position) {
-		return position;
-	}
+    public long getItemId(int position) {
+        return position;
+    }
 
-	public View getView(int position, View convertView, ViewGroup parent) {
-		SimpleMonthView v;
+    public View getView(int position, View convertView, ViewGroup parent) {
+        SimpleMonthView v;
         HashMap<String, Integer> drawingParams = null;
-		if (convertView != null) {
-			v = (SimpleMonthView) convertView;
+        if (convertView != null) {
+            v = (SimpleMonthView) convertView;
             drawingParams = (HashMap<String, Integer>) v.getTag();
         } else {
-			v = new SimpleMonthView(mContext);
-			v.setLayoutParams(new AbsListView.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
-			v.setClickable(true);
-			v.setOnDayClickListener(this);
-		}
+            v = new SimpleMonthView(mContext);
+            v.setLayoutParams(new AbsListView.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+            v.setClickable(true);
+            v.setOnDayClickListener(this);
+        }
         if (drawingParams == null) {
             drawingParams = new HashMap<String, Integer>();
         }
@@ -68,84 +74,132 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
             selectedDay = mSelectedDay.day;
         }
 
-		v.reuse();
+        v.reuse();
 
         drawingParams.put(SimpleMonthView.VIEW_PARAMS_SELECTED_DAY, selectedDay);
         drawingParams.put(SimpleMonthView.VIEW_PARAMS_YEAR, year);
         drawingParams.put(SimpleMonthView.VIEW_PARAMS_MONTH, month);
         drawingParams.put(SimpleMonthView.VIEW_PARAMS_WEEK_START, mController.getFirstDayOfWeek());
-		v.setMonthParams(drawingParams);
-		v.invalidate();
+        drawingParams.put(SimpleMonthView.VIEW_PARAMS_MIN_DATE_DAY, mMinDate.day);
+        drawingParams.put(SimpleMonthView.VIEW_PARAMS_MIN_DATE_MONTH, mMinDate.month);
+        drawingParams.put(SimpleMonthView.VIEW_PARAMS_MIN_DATE_YEAR, mMinDate.year);
+        v.setMonthParams(drawingParams);
+        v.invalidate();
 
-		return v;
-	}
+        return v;
+    }
 
-	protected void init() {
-		mSelectedDay = new CalendarDay(System.currentTimeMillis());
-	}
+    protected void init() {
+        mSelectedDay = new CalendarDay(System.currentTimeMillis());
+    }
 
-	public void onDayClick(SimpleMonthView simpleMonthView, CalendarDay calendarDay) {
-		if (calendarDay != null) {
-			onDayTapped(calendarDay);
-        }
-	}
-
-	protected void onDayTapped(CalendarDay calendarDay) {
-		mController.tryVibrate();
-		mController.onDayOfMonthSelected(calendarDay.year, calendarDay.month, calendarDay.day);
-		setSelectedDay(calendarDay);
-	}
-
-	public void setSelectedDay(CalendarDay calendarDay) {
-		mSelectedDay = calendarDay;
-		notifyDataSetChanged();
-	}
-
-	public static class CalendarDay {
-		private Calendar calendar;
-
-		int day;
-		int month;
-		int year;
-
-		public CalendarDay() {
-			setTime(System.currentTimeMillis());
-		}
-
-		public CalendarDay(int year, int month, int day) {
-			setDay(year, month, day);
-		}
-
-		public CalendarDay(long timeInMillis) {
-			setTime(timeInMillis);
-		}
-
-		public CalendarDay(Calendar calendar) {
-			year = calendar.get(Calendar.YEAR);
-			month = calendar.get(Calendar.MONTH);
-			day = calendar.get(Calendar.DAY_OF_MONTH);
-		}
-
-		private void setTime(long timeInMillis) {
-			if (calendar == null) {
-				calendar = Calendar.getInstance();
+    public void onDayClick(SimpleMonthView simpleMonthView, CalendarDay calendarDay) {
+        if (calendarDay != null) {
+            if (this.mMinDate == null || calendarDay.isAfter(this.mMinDate)) {
+                onDayTapped(calendarDay);
+            } else {
+                Log.i(TAG, "ignoring push since day is after mindate or mindate is not set");
             }
-			calendar.setTimeInMillis(timeInMillis);
-			month = this.calendar.get(Calendar.MONTH);
-			year = this.calendar.get(Calendar.YEAR);
-			day = this.calendar.get(Calendar.DAY_OF_MONTH);
-		}
+        }
+    }
 
-		public void set(CalendarDay calendarDay) {
-		    year = calendarDay.year;
-			month = calendarDay.month;
-			day = calendarDay.day;
-		}
+    protected void onDayTapped(CalendarDay calendarDay) {
+        mController.tryVibrate();
+        mController.onDayOfMonthSelected(calendarDay.year, calendarDay.month, calendarDay.day);
+        setSelectedDay(calendarDay);
+    }
 
-		public void setDay(int year, int month, int day) {
-			this.year = year;
-			this.month = month;
-			this.day = day;
-		}
-	}
+    public void setSelectedDay(CalendarDay calendarDay) {
+        mSelectedDay = calendarDay;
+        notifyDataSetChanged();
+    }
+
+    /**
+     * sets the min date. All previous days are disabled.
+     *
+     * @param mMinDate
+     */
+    public void setMinDate(CalendarDay mMinDate) {
+        this.mMinDate = mMinDate;
+        notifyDataSetChanged();
+    }
+
+    public static class CalendarDay {
+        private Calendar calendar;
+
+        int day;
+        int month;
+        int year;
+
+        public CalendarDay() {
+            setTime(System.currentTimeMillis());
+        }
+
+        public CalendarDay(int year, int month, int day) {
+            setDay(year, month, day);
+        }
+
+        public CalendarDay(long timeInMillis) {
+            setTime(timeInMillis);
+        }
+
+        public CalendarDay(Calendar calendar) {
+            year = calendar.get(Calendar.YEAR);
+            month = calendar.get(Calendar.MONTH);
+            day = calendar.get(Calendar.DAY_OF_MONTH);
+        }
+
+        private void setTime(long timeInMillis) {
+            if (calendar == null) {
+                calendar = Calendar.getInstance();
+            }
+            calendar.setTimeInMillis(timeInMillis);
+            month = this.calendar.get(Calendar.MONTH);
+            year = this.calendar.get(Calendar.YEAR);
+            day = this.calendar.get(Calendar.DAY_OF_MONTH);
+        }
+
+        public void set(CalendarDay calendarDay) {
+            year = calendarDay.year;
+            month = calendarDay.month;
+            day = calendarDay.day;
+        }
+
+        public void setDay(int year, int month, int day) {
+            this.year = year;
+            this.month = month;
+            this.day = day;
+        }
+
+        public boolean equals(CalendarDay o) {
+            if(o.year == year && o.day == day && o.month == month){
+                return true;
+            }
+            else return false;
+        }
+
+        /**
+         * returns true if day is after day
+         *
+         * @param day
+         * @return
+         */
+        public boolean isAfter(CalendarDay day) {
+            return convertToDate(this).after(convertToDate(day));
+        }
+
+        ;
+
+        public Date convertToDate(CalendarDay day) {
+            java.util.Date utilDate = null;
+
+            try {
+                SimpleDateFormat formatter = new SimpleDateFormat("yyyy/MM/dd");
+                utilDate = formatter.parse(day.year + "/" + day.month + "/" + day.day);
+            } catch (ParseException e) {
+                Log.e("SimpleMonthAdapter", "error while converting", e);
+            }
+            return utilDate;
+        }
+    }
 }

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
@@ -95,7 +95,7 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
 
     public void onDayClick(SimpleMonthView simpleMonthView, CalendarDay calendarDay) {
         if (calendarDay != null) {
-            if (this.mMinDate == null || calendarDay.isAfter(this.mMinDate)) {
+            if (this.mMinDate == null || calendarDay.isAfter(this.mMinDate) || calendarDay.equals(this.mMinDate)) {
                 onDayTapped(calendarDay);
             } else {
                 Log.i(TAG, "ignoring push since day is after mindate or mindate is not set");

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthView.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthView.java
@@ -31,8 +31,11 @@ public class SimpleMonthView extends View {
     public static final String VIEW_PARAMS_NUM_DAYS = "num_days";
     public static final String VIEW_PARAMS_FOCUS_MONTH = "focus_month";
     public static final String VIEW_PARAMS_SHOW_WK_NUM = "show_wk_num";
+    public static final String VIEW_PARAMS_MIN_DATE_DAY = "minDateDay";
 
     private static final int SELECTED_CIRCLE_ALPHA = 60;
+    public static final String VIEW_PARAMS_MIN_DATE_MONTH = "minDateMonth";
+    public static final String VIEW_PARAMS_MIN_DATE_YEAR ="minDateYear" ;
     protected static int DEFAULT_HEIGHT = 32;
     protected static final int DEFAULT_NUM_ROWS = 6;
 	protected static int DAY_SELECTED_CIRCLE_SIZE;
@@ -44,6 +47,7 @@ public class SimpleMonthView extends View {
 	protected static int MONTH_LABEL_TEXT_SIZE;
 
 	protected static float mScale = 0.0F;
+    private final int mDayDisabledTextColor;
     protected int mPadding = 0;
 
     private String mDayOfWeekTypeface;
@@ -87,8 +91,9 @@ public class SimpleMonthView extends View {
 	private DateFormatSymbols mDateFormatSymbols = new DateFormatSymbols();
 
     private OnDayClickListener mOnDayClickListener;
+    private SimpleMonthAdapter.CalendarDay mMinDate;
 
-	public SimpleMonthView(Context context) {
+    public SimpleMonthView(Context context) {
 		super(context);
 		Resources resources = context.getResources();
 		mDayLabelCalendar = Calendar.getInstance();
@@ -97,6 +102,7 @@ public class SimpleMonthView extends View {
 		mDayOfWeekTypeface = resources.getString(R.string.day_of_week_label_typeface);
 		mMonthTitleTypeface = resources.getString(R.string.sans_serif);
 		mDayTextColor = resources.getColor(R.color.date_picker_text_normal);
+        mDayDisabledTextColor = resources.getColor(R.color.done_text_color_disabled);
 		mTodayNumberColor = resources.getColor(R.color.blue);
 		mMonthTitleColor = resources.getColor(R.color.white);
 		mMonthTitleBGColor = resources.getColor(R.color.circle_background);
@@ -167,7 +173,10 @@ public class SimpleMonthView extends View {
 		int paddingDay = (mWidth - 2 * mPadding) / (2 * mNumDays);
 		int dayOffset = findDayOffset();
 		int day = 1;
-
+        boolean hasDisabledDays = false;
+        if(mMonth <= mMinDate.month && mYear <= mMinDate.year){
+            hasDisabledDays = true;
+        }
 		while (day <= mNumCells) {
 			int x = paddingDay * (1 + dayOffset * 2) + mPadding;
 			if (mSelectedDay == day) {
@@ -176,7 +185,12 @@ public class SimpleMonthView extends View {
             if (mHasToday && (mToday == day)) {
 				mMonthNumPaint.setColor(mTodayNumberColor);
             } else {
-				mMonthNumPaint.setColor(mDayTextColor);
+                mMonthNumPaint.setColor(mDayTextColor);
+                if(hasDisabledDays){
+                    if(mMinDate.isAfter(new SimpleMonthAdapter.CalendarDay(mYear,mMonth,day))){
+                        mMonthNumPaint.setColor(mDayDisabledTextColor);
+                    }
+                }
             }
 
 			canvas.drawText(String.format("%d", day), x, y, mMonthNumPaint);
@@ -278,6 +292,10 @@ public class SimpleMonthView extends View {
             throw new InvalidParameterException("You must specify month and year for this view");
         }
 		setTag(params);
+
+        if (params.containsKey(VIEW_PARAMS_MIN_DATE_DAY) && params.containsKey(VIEW_PARAMS_MIN_DATE_MONTH) && params.containsKey(VIEW_PARAMS_MIN_DATE_YEAR)) {
+            this.mMinDate = new SimpleMonthAdapter.CalendarDay(params.get(VIEW_PARAMS_MIN_DATE_YEAR), params.get(VIEW_PARAMS_MIN_DATE_MONTH), params.get(VIEW_PARAMS_MIN_DATE_DAY));
+        }
 
         if (params.containsKey(VIEW_PARAMS_HEIGHT)) {
             mRowHeight = params.get(VIEW_PARAMS_HEIGHT);

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthView.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthView.java
@@ -265,8 +265,8 @@ public class SimpleMonthView extends View {
 	}
 
 	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-		setMeasuredDimension(View.MeasureSpec.getSize(widthMeasureSpec), mRowHeight * mNumRows + MONTH_HEADER_SIZE);
-	}
+        setMeasuredDimension(View.MeasureSpec.getSize(widthMeasureSpec), mRowHeight * mNumRows + MONTH_HEADER_SIZE + getResources().getDimensionPixelOffset(R.dimen.month_view_bottom_pad));
+    }
 
 	protected void onSizeChanged(int w, int h, int oldw, int oldh) {
 		mWidth = w;


### PR DESCRIPTION
What was painfully missing was the ability to disable dates in the past. 
With these changes it will be easily possible.
just call the method setMinDate() on the dialog:

datePickerDialog.setMinDate(new SimpleMonthAdapter.CalendarDay(2015,4,25));

the disabled dates will not respond to touch and will be colored lighter gray.
