### PR TITLE
Add method to highlight days

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-alpha4'
+        classpath 'com.android.tools.build:gradle:2.1.0-alpha5'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.2'
+        classpath 'com.android.tools.build:gradle:2.1.0-alpha4'
     }
 }
 
@@ -12,7 +12,7 @@ allprojects {
     group = GROUP
 
     repositories {
-        mavenCentral()
+        jcenter()
     }
 }
 

--- a/datetimepicker-library/build.gradle
+++ b/datetimepicker-library/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 20
     buildToolsVersion "19.1.0"
 
     defaultConfig {

--- a/datetimepicker-library/res/layout-land/time_picker_dialog.xml
+++ b/datetimepicker-library/res/layout-land/time_picker_dialog.xml
@@ -15,6 +15,7 @@
   ~ limitations under the License
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/time_picker_dialog"
     android:layout_height="@dimen/dialog_height"
     android:layout_width="wrap_content"
@@ -48,7 +49,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:background="@color/white" >
+            android:background="@color/white"
+            tools:ignore="NewApi">
             <Button
                 android:id="@+id/done_button"
                 style="?android:attr/buttonBarButtonStyle"

--- a/datetimepicker-library/res/layout/date_picker_done_button.xml
+++ b/datetimepicker-library/res/layout/date_picker_done_button.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="@dimen/date_picker_component_width"
     android:layout_height="wrap_content"
-    style="?android:attr/buttonBarStyle">
+    style="?android:attr/buttonBarStyle"
+    tools:ignore="NewApi">
 
     <Button
         android:textSize="@dimen/done_label_size"

--- a/datetimepicker-library/res/layout/time_picker_dialog.xml
+++ b/datetimepicker-library/res/layout/time_picker_dialog.xml
@@ -15,6 +15,7 @@
   ~ limitations under the License
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -47,7 +48,8 @@
         style="?android:attr/buttonBarStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal" >
+        android:orientation="horizontal"
+        tools:ignore="NewApi">
         <Button
             android:id="@+id/done_button"
             android:layout_width="match_parent"

--- a/datetimepicker-library/res/values-v16/strings.xml
+++ b/datetimepicker-library/res/values-v16/strings.xml
@@ -14,7 +14,7 @@
      limitations under the License.
 -->
 
-<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <!-- DO NOT TRANSLATE -->
-    <string name="day_of_week_label_typeface">sans-serif-light</string>
+    <string name="day_of_week_label_typeface" tools:ignore="ExtraTranslation,MissingTranslation">sans-serif-light</string>
 </resources>

--- a/datetimepicker-library/res/values/colors.xml
+++ b/datetimepicker-library/res/values/colors.xml
@@ -6,6 +6,7 @@
     <color name="done_text_color_normal">#ff333333</color>
     <color name="done_text_color_disabled">#ffcccccc</color>
     <color name="blue">#ff33b5e5</color>
+    <color name="orange">#ffab40</color>
     <color name="darker_blue">#ff0099cc</color>
     <color name="date_picker_text_normal">#ff999999</color>
     <color name="calendar_header">#ff999999</color>

--- a/datetimepicker-library/res/values/strings.xml
+++ b/datetimepicker-library/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:xliff="http://schemas.android.com/apk/res/android">
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="http://schemas.android.com/apk/res/android">
     <string name="done_label">Done</string>
     <string name="day_picker_description">Month grid of days</string>
     <string name="year_picker_description">Year list</string>
@@ -7,7 +7,7 @@
     <string name="select_year">Select year</string>
     <string name="item_is_selected">%1$s selected</string>
     <string name="sans_serif" translatable="false">sans-serif</string>
-    <string name="day_of_week_label_typeface" translatable="false">sans-serif</string>
+    <string name="day_of_week_label_typeface" translatable="false" tools:ignore="MissingTranslation">sans-serif</string>
 
     <string name="time_placeholder" translatable="false">--</string>
     <string name="time_separator" translatable="false">:</string>

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/ArrayUtils.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/ArrayUtils.java
@@ -1,0 +1,16 @@
+package com.fourmob.datetimepicker;
+
+public final class ArrayUtils {
+
+    private ArrayUtils() {
+    }
+
+    public static boolean contains(int[] arr, int value) {
+        for (int i = 0; i < arr.length; i++) {
+            if (arr[i] == value) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerController.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerController.java
@@ -1,5 +1,7 @@
 package com.fourmob.datetimepicker.date;
 
+import java.util.List;
+
 abstract interface DatePickerController {
 	public abstract int getFirstDayOfWeek();
 
@@ -8,6 +10,8 @@ abstract interface DatePickerController {
 	public abstract int getMinYear();
 
 	public abstract SimpleMonthAdapter.CalendarDay getSelectedDay();
+
+	public abstract List<SimpleMonthAdapter.CalendarDay> getHighlightedDays();
 
 	public abstract void onDayOfMonthSelected(int year, int month, int day);
 

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
@@ -1,6 +1,7 @@
 package com.fourmob.datetimepicker.date;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.SystemClock;
@@ -24,8 +25,10 @@ import com.nineoldandroids.animation.ObjectAnimator;
 import java.text.DateFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 
 public class DatePickerDialog extends DialogFragment implements View.OnClickListener, DatePickerController {
@@ -56,6 +59,7 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
     private DateFormatSymbols mDateFormatSymbols = new DateFormatSymbols();
 
 	private final Calendar mCalendar = Calendar.getInstance();
+	private List<SimpleMonthAdapter.CalendarDay> mHighlightedDays;
     private HashSet<OnDateChangedListener> mListeners = new HashSet<OnDateChangedListener>();
     private OnDateSetListener mCallBack;
 
@@ -108,6 +112,9 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
 		return datePickerDialog;
 	}
 
+    public void setHighlightedDays(List<SimpleMonthAdapter.CalendarDay> highlightedDays) {
+		mHighlightedDays = highlightedDays;
+	}
 
 	public void setVibrate(boolean vibrate) {
 		mVibrate = vibrate;
@@ -215,6 +222,10 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
 		return new SimpleMonthAdapter.CalendarDay(mCalendar);
 	}
 
+	@Override public List<SimpleMonthAdapter.CalendarDay> getHighlightedDays() {
+		return Collections.unmodifiableList(mHighlightedDays);
+	}
+
 	public void initialize(OnDateSetListener onDateSetListener, int year, int month, int day, boolean vibrate) {
 		if (year > MAX_YEAR)
 			throw new IllegalArgumentException("year end must < " + MAX_YEAR);
@@ -239,7 +250,7 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
 		super.onCreate(bundle);
 		Activity activity = getActivity();
 		activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-		mVibrator = ((Vibrator) activity.getSystemService("vibrator"));
+		mVibrator = ((Vibrator) activity.getSystemService(Context.VIBRATOR_SERVICE));
 		if (bundle != null) {
 			mCalendar.set(Calendar.YEAR, bundle.getInt(KEY_SELECTED_YEAR));
 			mCalendar.set(Calendar.MONTH, bundle.getInt(KEY_SELECTED_MONTH));

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DatePickerDialog.java
@@ -6,6 +6,7 @@ import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.os.Vibrator;
+import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
 import android.text.format.DateUtils;
 import android.view.LayoutInflater;
@@ -25,6 +26,7 @@ import com.nineoldandroids.animation.ObjectAnimator;
 import java.text.DateFormatSymbols;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -59,7 +61,7 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
     private DateFormatSymbols mDateFormatSymbols = new DateFormatSymbols();
 
 	private final Calendar mCalendar = Calendar.getInstance();
-	private List<SimpleMonthAdapter.CalendarDay> mHighlightedDays;
+	private @NonNull List<SimpleMonthAdapter.CalendarDay> mHighlightedDays = Collections.emptyList();
     private HashSet<OnDateChangedListener> mListeners = new HashSet<OnDateChangedListener>();
     private OnDateSetListener mCallBack;
 
@@ -112,7 +114,7 @@ public class DatePickerDialog extends DialogFragment implements View.OnClickList
 		return datePickerDialog;
 	}
 
-    public void setHighlightedDays(List<SimpleMonthAdapter.CalendarDay> highlightedDays) {
+    public void setHighlightedDays(@NonNull List<SimpleMonthAdapter.CalendarDay> highlightedDays) {
 		mHighlightedDays = highlightedDays;
 	}
 

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/DayPickerView.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/DayPickerView.java
@@ -243,10 +243,20 @@ public class DayPickerView extends ListView implements AbsListView.OnScrollListe
                 final int bottom = child.getBottom();
                 final int midpoint = getHeight() / 2;
                 if (scroll && top < LIST_TOP_OFFSET) {
-                    if (bottom > midpoint) {
-                        smoothScrollBy(top, GOTO_SCROLL_DURATION);
+                    if (Build.VERSION.SDK_INT > 7){
+                        if (bottom > midpoint) {
+                            smoothScrollBy(top, GOTO_SCROLL_DURATION);
+                        } else {
+                            smoothScrollBy(bottom, GOTO_SCROLL_DURATION);
+                        }
                     } else {
-                        smoothScrollBy(bottom, GOTO_SCROLL_DURATION);
+                        if (bottom > midpoint) {
+                            //noinspection SuspiciousNameCombination
+                            scrollBy(top, GOTO_SCROLL_DURATION);
+                        } else {
+                            //noinspection SuspiciousNameCombination
+                            scrollBy(bottom, GOTO_SCROLL_DURATION);
+                        }
                     }
                 }
             } else {

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
@@ -7,8 +7,10 @@ import android.view.ViewGroup.LayoutParams;
 import android.widget.AbsListView;
 import android.widget.BaseAdapter;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.List;
 
 public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.OnDayClickListener {
 
@@ -19,12 +21,14 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
 	private final DatePickerController mController;
 
 	private CalendarDay mSelectedDay;
+	private List<CalendarDay> mHighlightedDays;
 
 	public SimpleMonthAdapter(Context context, DatePickerController datePickerController) {
 		mContext = context;
 		mController = datePickerController;
 		init();
 		setSelectedDay(mController.getSelectedDay());
+        setHighlightedDays(mController.getHighlightedDays());
 	}
 
 	private boolean isSelectedDayInMonth(int year, int month) {
@@ -45,10 +49,10 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
 
 	public View getView(int position, View convertView, ViewGroup parent) {
 		SimpleMonthView v;
-        HashMap<String, Integer> drawingParams = null;
+        HashMap<String, Object> drawingParams = null;
 		if (convertView != null) {
 			v = (SimpleMonthView) convertView;
-            drawingParams = (HashMap<String, Integer>) v.getTag();
+            drawingParams = (HashMap<String, Object>) v.getTag();
         } else {
 			v = new SimpleMonthView(mContext);
 			v.setLayoutParams(new AbsListView.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
@@ -56,7 +60,7 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
 			v.setOnDayClickListener(this);
 		}
         if (drawingParams == null) {
-            drawingParams = new HashMap<String, Integer>();
+            drawingParams = new HashMap<String, Object>();
         }
         drawingParams.clear();
 
@@ -67,10 +71,12 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
         if (isSelectedDayInMonth(year, month)) {
             selectedDay = mSelectedDay.day;
         }
+		int[] highlightedDays = daysInThisMonth(mHighlightedDays, year, month);
 
 		v.reuse();
 
         drawingParams.put(SimpleMonthView.VIEW_PARAMS_SELECTED_DAY, selectedDay);
+		drawingParams.put(SimpleMonthView.VIEW_PARAMS_HIGHLIGHTED_DAYS, highlightedDays);
         drawingParams.put(SimpleMonthView.VIEW_PARAMS_YEAR, year);
         drawingParams.put(SimpleMonthView.VIEW_PARAMS_MONTH, month);
         drawingParams.put(SimpleMonthView.VIEW_PARAMS_WEEK_START, mController.getFirstDayOfWeek());
@@ -78,6 +84,25 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
 		v.invalidate();
 
 		return v;
+	}
+
+	/**
+	 * Filter out any days not in the specified month and year
+	 * and return an integer array of days in this month.
+     */
+	private static int[] daysInThisMonth(List<CalendarDay> highlightedDays, int year, int month) {
+		List<Integer> daysInMonth = new ArrayList<Integer>();
+		for (CalendarDay highlightedDay : highlightedDays) {
+			if (highlightedDay.month == month && highlightedDay.year == year) {
+				daysInMonth.add(highlightedDay.day);
+			}
+		}
+		int[] daysInMonthArr = new int[daysInMonth.size()];
+		for (int i = 0; i < daysInMonth.size(); i++) {
+			daysInMonthArr[i] = daysInMonth.get(i);
+		}
+
+		return daysInMonthArr;
 	}
 
 	protected void init() {
@@ -100,6 +125,11 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
 		mSelectedDay = calendarDay;
 		notifyDataSetChanged();
 	}
+
+    public void setHighlightedDays(List<CalendarDay> calendarDays) {
+        mHighlightedDays = calendarDays;
+        notifyDataSetChanged();
+    }
 
 	public static class CalendarDay {
 		private Calendar calendar;

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
@@ -177,5 +177,28 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
 			this.month = month;
 			this.day = day;
 		}
+
+		@Override public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (o == null || getClass() != o.getClass())
+				return false;
+
+			CalendarDay that = (CalendarDay) o;
+
+			if (day != that.day)
+				return false;
+			if (month != that.month)
+				return false;
+			return year == that.year;
+
+		}
+
+		@Override public int hashCode() {
+			int result = day;
+			result = 31 * result + month;
+			result = 31 * result + year;
+			return result;
+		}
 	}
 }

--- a/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
+++ b/datetimepicker-library/src/com/fourmob/datetimepicker/date/SimpleMonthAdapter.java
@@ -200,5 +200,13 @@ public class SimpleMonthAdapter extends BaseAdapter implements SimpleMonthView.O
 			result = 31 * result + year;
 			return result;
 		}
+
+		@Override public String toString() {
+			return "CalendarDay{" +
+					"day=" + day +
+					", month=" + month +
+					", year=" + year +
+					'}';
+		}
 	}
 }

--- a/datetimepicker-library/src/com/sleepbot/datetimepicker/time/RadialPickerLayout.java
+++ b/datetimepicker-library/src/com/sleepbot/datetimepicker/time/RadialPickerLayout.java
@@ -559,8 +559,8 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
             mTransition.start();
         } else {
             if (Build.VERSION.SDK_INT >= 11) {
-                int hourAlpha = (index == HOUR_INDEX) ? 255 : 0;
-                int minuteAlpha = (index == MINUTE_INDEX) ? 255 : 0;
+                int hourAlpha = (index == HOUR_INDEX) ? 1 : 0;
+                int minuteAlpha = (index == MINUTE_INDEX) ? 1 : 0;
                 mHourRadialTextsView.setAlpha(hourAlpha);
                 mHourRadialSelectorView.setAlpha(hourAlpha);
                 mMinuteRadialTextsView.setAlpha(minuteAlpha);

--- a/datetimepicker-sample/res/values/strings.xml
+++ b/datetimepicker-sample/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
-    <string name="app_name">DateTimePicker sample</string>
+    <string name="app_name" tools:ignore="MissingTranslation">DateTimePicker sample</string>
 
 </resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 02 21:48:24 CEST 2014
+#Mon Apr 04 12:47:00 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
This PR fixes the build in newer versions of Android Studio and adds a method `DatePickerDialog.setHighlightedDays(List<CalendarDay>)`. The supplied days are highlighted in orange.
A use case: Highlighting days that have appointments to allow a user to quickly switch to them.
